### PR TITLE
(#5) Add local message storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .ruff_cache/
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-08-29
+
+### Added
+- Local SQLite message persistence with `MessageStorage` repository (`#5`).
+- Domain models `Message`, `MessageDirection`, and `MessageStatus` with UTC timestamp tracking (`created_at`, `modified_at`) (`#5`).
+- Persistent storage integration in `GatewayService` and configurable database path in `GatewayConfig` (`#5`).
+- Comprehensive unit and integration test suite in `tests/test_storage.py` covering persistence, CRUD operations, filtering, pagination, and service restarts (`#5`).
+- System architecture documentation and Mermaid data schema diagram for local message storage (`#5`).
+
 ## [0.2.0] - 2026-08-29
+
 
 ### Added
 - Gateway application skeleton with `GatewayService` lifecycle management and run loop (`#4`).

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -21,17 +21,21 @@ snippen-sms-service/
 │       ├── __init__.py       # Package version & exports
 │       ├── config.py         # Gateway configuration settings
 │       ├── gateway.py        # GatewayService lifecycle & run loop
-│       └── main.py           # Entry point & CLI runner
+│       ├── main.py           # Entry point & CLI runner
+│       ├── models.py         # Message domain models and enums
+│       └── storage.py        # SQLite persistent storage repository
 ├── tests/
 │   ├── conftest.py           # Pytest fixtures
 │   ├── test_format.py        # Formatter tests
 │   ├── test_gateway.py       # GatewayService lifecycle tests
 │   ├── test_main.py          # Unit tests
+│   ├── test_storage.py       # SQLite message storage unit & integration tests
 │   └── test_validate_pr.py   # PR validation tests
 ├── pyproject.toml            # Python packaging and dependency config
 ├── README.md                 # User documentation
 ├── DEV_README.md             # Developer documentation
 └── CHANGELOG.md              # Project history
+
 ```
 
 For high-level system architecture, communication flows, and boundaries, see [docs/architecture.md](file:///workspaces/snippen-sms-service/docs/architecture.md).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ A lightweight, dedicated two-way SMS gateway service designed for the **Snippen*
 
 ---
 
+## Configuration
+
+The gateway service can be configured via CLI flags or environment variables:
+
+| Setting | Environment Variable | Default | Description |
+| :--- | :--- | :--- | :--- |
+| Service Name | `SNIPPEN_SMS_SERVICE_NAME` | `snippen-sms-service` | Name of the service instance |
+| Log Level | `SNIPPEN_SMS_LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| Poll Interval | `SNIPPEN_SMS_POLL_INTERVAL` | `2.0` | Polling loop tick interval in seconds |
+| Database Path | `SNIPPEN_SMS_DATABASE_PATH` | `data/sms_gateway.db` | Path to SQLite database file (or `:memory:`) |
+
+---
+
 ## Quick Start (Development)
 
 Start the long-running SMS gateway service:
@@ -42,7 +55,7 @@ Start the long-running SMS gateway service:
 # Start gateway service
 python -m snippen_sms.main
 
-# Or run with custom poll interval and log level
+# Or run with custom poll interval, log level, and database path
 python -m snippen_sms.main --poll-interval 1.0 --log-level DEBUG
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,6 +105,33 @@ sequenceDiagram
 
 ---
 
+## Local Message Persistence
+
+To ensure zero message loss during network interruptions or service restarts, the SMS Gateway employs a lightweight, embedded SQLite database backend. Messages are persisted locally before and after transmission or ingestion.
+
+### Data Model & Schema
+
+```mermaid
+erDiagram
+    messages {
+        int id PK
+        string direction
+        string sender
+        string recipient
+        string body
+        string status
+        string modem_message_id
+        string error_message
+        string created_at
+        string modified_at
+    }
+```
+
+- **Persistence Layer (`MessageStorage`)**: Built on Python standard library `sqlite3` using Write-Ahead Logging (`WAL`) mode for robust, concurrent reads and writes without external database server dependencies.
+- **Timestamp Tracking**: Every record maintains ISO-8601 UTC `created_at` and `modified_at` timestamps for auditing, synchronization, and retry workflows.
+
+---
+
 ## Architectural Principles
 
 1. **Hardware Isolation**:

--- a/src/snippen_sms/__init__.py
+++ b/src/snippen_sms/__init__.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 from snippen_sms.config import GatewayConfig
 from snippen_sms.gateway import GatewayService
+from snippen_sms.models import Message, MessageDirection, MessageStatus
+from snippen_sms.storage import MessageStorage
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
-__all__ = ["GatewayConfig", "GatewayService", "__version__"]
+__all__ = [
+    "GatewayConfig",
+    "GatewayService",
+    "Message",
+    "MessageDirection",
+    "MessageStatus",
+    "MessageStorage",
+    "__version__",
+]

--- a/src/snippen_sms/config.py
+++ b/src/snippen_sms/config.py
@@ -13,6 +13,7 @@ class GatewayConfig:
     service_name: str = "snippen-sms-service"
     log_level: str = "INFO"
     poll_interval_seconds: float = 2.0
+    database_path: str = "data/sms_gateway.db"
 
     @classmethod
     def from_env(cls) -> GatewayConfig:
@@ -21,4 +22,5 @@ class GatewayConfig:
             service_name=os.getenv("SNIPPEN_SMS_SERVICE_NAME", "snippen-sms-service"),
             log_level=os.getenv("SNIPPEN_SMS_LOG_LEVEL", "INFO").upper(),
             poll_interval_seconds=float(os.getenv("SNIPPEN_SMS_POLL_INTERVAL", "2.0")),
+            database_path=os.getenv("SNIPPEN_SMS_DATABASE_PATH", "data/sms_gateway.db"),
         )

--- a/src/snippen_sms/gateway.py
+++ b/src/snippen_sms/gateway.py
@@ -8,6 +8,7 @@ import time
 from typing import Any
 
 from snippen_sms.config import GatewayConfig
+from snippen_sms.storage import MessageStorage
 
 logger = logging.getLogger("snippen_sms.gateway")
 
@@ -15,8 +16,13 @@ logger = logging.getLogger("snippen_sms.gateway")
 class GatewayService:
     """Long-running gateway service managing SMS dispatch and ingestion."""
 
-    def __init__(self, config: GatewayConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: GatewayConfig | None = None,
+        storage: MessageStorage | None = None,
+    ) -> None:
         self.config = config or GatewayConfig()
+        self.storage = storage or MessageStorage(self.config.database_path)
         self._is_running = False
         self._stop_event = asyncio.Event()
         self._start_time: float | None = None
@@ -43,6 +49,8 @@ class GatewayService:
             "version": __version__,
             "uptime_seconds": round(self.uptime_seconds, 2),
             "poll_interval_seconds": self.config.poll_interval_seconds,
+            "database_path": self.config.database_path,
+            "total_messages": self.storage.count_messages(),
         }
 
     async def start(self) -> None:
@@ -68,6 +76,7 @@ class GatewayService:
         logger.info("Stopping %s...", self.config.service_name)
         self._is_running = False
         self._stop_event.set()
+        self.storage.close()
 
     async def run(self) -> None:
         """Main service execution loop."""

--- a/src/snippen_sms/models.py
+++ b/src/snippen_sms/models.py
@@ -1,0 +1,68 @@
+"""Domain models for Snippen SMS Service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+
+class MessageDirection(str, Enum):
+    """Direction of the SMS message."""
+
+    INBOUND = "inbound"
+    OUTBOUND = "outbound"
+
+
+class MessageStatus(str, Enum):
+    """Lifecycle status of an SMS message."""
+
+    PENDING = "pending"
+    QUEUED = "queued"
+    SENT = "sent"
+    RECEIVED = "received"
+    FAILED = "failed"
+    DELIVERED = "delivered"
+
+
+@dataclass
+class Message:
+    """Represents an SMS message handled by the gateway."""
+
+    direction: MessageDirection
+    sender: str
+    recipient: str
+    body: str
+    id: int | None = None
+    status: MessageStatus = MessageStatus.PENDING
+    modem_message_id: str | None = None
+    error_message: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    modified_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        """Validate and normalize enum fields."""
+        if isinstance(self.direction, str) and not isinstance(self.direction, MessageDirection):
+            self.direction = MessageDirection(self.direction)
+        if isinstance(self.status, str) and not isinstance(self.status, MessageStatus):
+            self.status = MessageStatus(self.status)
+        if self.created_at.tzinfo is None:
+            self.created_at = self.created_at.replace(tzinfo=UTC)
+        if self.modified_at.tzinfo is None:
+            self.modified_at = self.modified_at.replace(tzinfo=UTC)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert message to dictionary representation."""
+        return {
+            "id": self.id,
+            "direction": self.direction.value,
+            "sender": self.sender,
+            "recipient": self.recipient,
+            "body": self.body,
+            "status": self.status.value,
+            "modem_message_id": self.modem_message_id,
+            "error_message": self.error_message,
+            "created_at": self.created_at.isoformat(),
+            "modified_at": self.modified_at.isoformat(),
+        }

--- a/src/snippen_sms/storage.py
+++ b/src/snippen_sms/storage.py
@@ -1,0 +1,282 @@
+"""SQLite message storage layer for Snippen SMS Service."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Self
+
+from snippen_sms.models import Message, MessageDirection, MessageStatus
+
+logger = logging.getLogger("snippen_sms.storage")
+
+
+class MessageStorage:
+    """Persistent message repository backed by SQLite."""
+
+    def __init__(self, db_path: str | Path = "data/sms_gateway.db") -> None:
+        self.db_path = str(db_path)
+        self._conn: sqlite3.Connection | None = None
+        # Ensure connection and schema are initialized
+        _ = self.connection
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        """Return active database connection, establishing and setting up schema if not open."""
+        if self._conn is None:
+            if self.db_path != ":memory:":
+                Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(self.db_path, check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            self._setup_schema(conn)
+            self._conn = conn
+        return self._conn
+
+    def _setup_schema(self, conn: sqlite3.Connection) -> None:
+        """Initialize database tables and indexes on the connection."""
+        with conn:
+            if self.db_path != ":memory:":
+                conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA foreign_keys=ON;")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    direction TEXT NOT NULL,
+                    sender TEXT NOT NULL,
+                    recipient TEXT NOT NULL,
+                    body TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    modem_message_id TEXT,
+                    error_message TEXT,
+                    created_at TEXT NOT NULL,
+                    modified_at TEXT NOT NULL
+                );
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_messages_status ON messages(status);")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_messages_direction ON messages(direction);"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);"
+            )
+        logger.debug("MessageStorage initialized with backend: %s", self.db_path)
+
+    @staticmethod
+    def _row_to_message(row: sqlite3.Row) -> Message:
+        """Convert a database Row to a Message instance."""
+        created_at_dt = datetime.fromisoformat(row["created_at"])
+        if created_at_dt.tzinfo is None:
+            created_at_dt = created_at_dt.replace(tzinfo=UTC)
+
+        modified_at_dt = datetime.fromisoformat(row["modified_at"])
+        if modified_at_dt.tzinfo is None:
+            modified_at_dt = modified_at_dt.replace(tzinfo=UTC)
+
+        return Message(
+            id=row["id"],
+            direction=MessageDirection(row["direction"]),
+            sender=row["sender"],
+            recipient=row["recipient"],
+            body=row["body"],
+            status=MessageStatus(row["status"]),
+            modem_message_id=row["modem_message_id"],
+            error_message=row["error_message"],
+            created_at=created_at_dt,
+            modified_at=modified_at_dt,
+        )
+
+    def save_message(self, message: Message) -> Message:
+        """Save a new message or update an existing message."""
+        now = datetime.now(UTC)
+        conn = self.connection
+
+        if message.id is None:
+            message.created_at = message.created_at or now
+            message.modified_at = now
+            with conn:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO messages (
+                        direction, sender, recipient, body, status,
+                        modem_message_id, error_message, created_at, modified_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        message.direction.value,
+                        message.sender,
+                        message.recipient,
+                        message.body,
+                        message.status.value,
+                        message.modem_message_id,
+                        message.error_message,
+                        message.created_at.isoformat(),
+                        message.modified_at.isoformat(),
+                    ),
+                )
+                message.id = cursor.lastrowid
+            logger.debug("Saved new message with id=%s", message.id)
+            return message
+
+        message.modified_at = now
+        with conn:
+            conn.execute(
+                """
+                UPDATE messages SET
+                    direction = ?,
+                    sender = ?,
+                    recipient = ?,
+                    body = ?,
+                    status = ?,
+                    modem_message_id = ?,
+                    error_message = ?,
+                    modified_at = ?
+                WHERE id = ?
+                """,
+                (
+                    message.direction.value,
+                    message.sender,
+                    message.recipient,
+                    message.body,
+                    message.status.value,
+                    message.modem_message_id,
+                    message.error_message,
+                    message.modified_at.isoformat(),
+                    message.id,
+                ),
+            )
+        logger.debug("Updated existing message with id=%s", message.id)
+        return message
+
+    def get_message(self, message_id: int) -> Message | None:
+        """Retrieve a message by its ID."""
+        cursor = self.connection.execute(
+            "SELECT * FROM messages WHERE id = ?",
+            (message_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return self._row_to_message(row)
+
+    def list_messages(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        status: MessageStatus | str | None = None,
+        direction: MessageDirection | str | None = None,
+    ) -> list[Message]:
+        """List messages with optional status and direction filtering and pagination."""
+        query = "SELECT * FROM messages"
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if status is not None:
+            status_val = status.value if isinstance(status, MessageStatus) else str(status)
+            conditions.append("status = ?")
+            params.append(status_val)
+
+        if direction is not None:
+            dir_val = direction.value if isinstance(direction, MessageDirection) else str(direction)
+            conditions.append("direction = ?")
+            params.append(dir_val)
+
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+
+        query += " ORDER BY id DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+
+        cursor = self.connection.execute(query, tuple(params))
+        return [self._row_to_message(row) for row in cursor.fetchall()]
+
+    def update_message_status(
+        self,
+        message_id: int,
+        status: MessageStatus | str,
+        error_message: str | None = None,
+        modem_message_id: str | None = None,
+    ) -> Message | None:
+        """Update the status and optional metadata of a message."""
+        status_val = status.value if isinstance(status, MessageStatus) else str(status)
+        now = datetime.now(UTC).isoformat()
+
+        # Build update dynamically to avoid overriding modem_message_id/error_message if None unless supplied
+        update_clauses = ["status = ?", "modified_at = ?"]
+        params: list[Any] = [status_val, now]
+
+        if error_message is not None:
+            update_clauses.append("error_message = ?")
+            params.append(error_message)
+
+        if modem_message_id is not None:
+            update_clauses.append("modem_message_id = ?")
+            params.append(modem_message_id)
+
+        params.append(message_id)
+        query = f"UPDATE messages SET {', '.join(update_clauses)} WHERE id = ?"
+
+        with self.connection:
+            cursor = self.connection.execute(query, tuple(params))
+            if cursor.rowcount == 0:
+                return None
+
+        return self.get_message(message_id)
+
+    def delete_message(self, message_id: int) -> bool:
+        """Delete a message by its ID."""
+        with self.connection:
+            cursor = self.connection.execute(
+                "DELETE FROM messages WHERE id = ?",
+                (message_id,),
+            )
+            return cursor.rowcount > 0
+
+    def count_messages(
+        self,
+        status: MessageStatus | str | None = None,
+        direction: MessageDirection | str | None = None,
+    ) -> int:
+        """Count total messages matching criteria."""
+        query = "SELECT COUNT(*) FROM messages"
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if status is not None:
+            status_val = status.value if isinstance(status, MessageStatus) else str(status)
+            conditions.append("status = ?")
+            params.append(status_val)
+
+        if direction is not None:
+            dir_val = direction.value if isinstance(direction, MessageDirection) else str(direction)
+            conditions.append("direction = ?")
+            params.append(dir_val)
+
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+
+        cursor = self.connection.execute(query, tuple(params))
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+            logger.debug("Closed database connection for %s", self.db_path)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -11,22 +11,25 @@ def test_gateway_config_defaults():
     assert config.service_name == "snippen-sms-service"
     assert config.log_level == "INFO"
     assert config.poll_interval_seconds == 2.0
+    assert config.database_path == "data/sms_gateway.db"
 
 
 def test_gateway_config_from_env(monkeypatch):
     monkeypatch.setenv("SNIPPEN_SMS_SERVICE_NAME", "custom-gateway")
     monkeypatch.setenv("SNIPPEN_SMS_LOG_LEVEL", "debug")
     monkeypatch.setenv("SNIPPEN_SMS_POLL_INTERVAL", "5.5")
+    monkeypatch.setenv("SNIPPEN_SMS_DATABASE_PATH", ":memory:")
 
     config = GatewayConfig.from_env()
     assert config.service_name == "custom-gateway"
     assert config.log_level == "DEBUG"
     assert config.poll_interval_seconds == 5.5
+    assert config.database_path == ":memory:"
 
 
 def test_gateway_start_and_stop():
     async def _test():
-        config = GatewayConfig(poll_interval_seconds=0.05)
+        config = GatewayConfig(poll_interval_seconds=0.05, database_path=":memory:")
         service = GatewayService(config)
 
         assert not service.is_running
@@ -39,7 +42,9 @@ def test_gateway_start_and_stop():
         status = service.get_status()
         assert status["status"] == "running"
         assert status["service"] == "snippen-sms-service"
-        assert status["version"] == "0.2.0"
+        assert status["version"] == "0.3.0"
+        assert status["database_path"] == ":memory:"
+        assert status["total_messages"] == 0
 
         await service.stop()
         assert not service.is_running
@@ -50,7 +55,7 @@ def test_gateway_start_and_stop():
 
 def test_gateway_run_loop_and_graceful_stop():
     async def _test():
-        config = GatewayConfig(poll_interval_seconds=0.05)
+        config = GatewayConfig(poll_interval_seconds=0.05, database_path=":memory:")
         service = GatewayService(config)
 
         task = asyncio.create_task(service.run())
@@ -69,7 +74,7 @@ def test_gateway_run_loop_and_graceful_stop():
 
 def test_gateway_run_cancellation():
     async def _test():
-        config = GatewayConfig(poll_interval_seconds=0.05)
+        config = GatewayConfig(poll_interval_seconds=0.05, database_path=":memory:")
         service = GatewayService(config)
 
         task = asyncio.create_task(service.run())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ def test_get_status():
     status = get_status()
     assert status["status"] in ("stopped", "running")
     assert status["service"] == "snippen-sms-service"
-    assert status["version"] == "0.2.0"
+    assert status["version"] == "0.3.0"
 
 
 def test_setup_logging():

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,303 @@
+"""Unit and integration tests for SQLite message storage."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC
+from pathlib import Path
+
+import pytest
+
+from snippen_sms.models import Message, MessageDirection, MessageStatus
+from snippen_sms.storage import MessageStorage
+
+
+@pytest.fixture
+def memory_storage() -> MessageStorage:
+    """Create an in-memory MessageStorage instance."""
+    storage = MessageStorage(":memory:")
+    yield storage
+    storage.close()
+
+
+def test_models_enum_coercion_and_to_dict() -> None:
+    """Test Message model validation and dict serialization."""
+    msg = Message(
+        direction="inbound",  # type: ignore[arg-type]
+        sender="+4712345678",
+        recipient="+4787654321",
+        body="Hei fra gjest",
+        status="received",  # type: ignore[arg-type]
+    )
+    assert msg.direction == MessageDirection.INBOUND
+    assert msg.status == MessageStatus.RECEIVED
+    assert msg.created_at.tzinfo == UTC
+    assert msg.modified_at.tzinfo == UTC
+
+    d = msg.to_dict()
+    assert d["direction"] == "inbound"
+    assert d["status"] == "received"
+    assert d["sender"] == "+4712345678"
+    assert d["body"] == "Hei fra gjest"
+
+
+def test_storage_initialization_memory(memory_storage: MessageStorage) -> None:
+    """Test initializing storage in memory creates tables and indexes."""
+    assert memory_storage.connection is not None
+    cursor = memory_storage.connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='messages';"
+    )
+    assert cursor.fetchone() is not None
+
+
+def test_storage_initialization_file(tmp_path: Path) -> None:
+    """Test initializing storage on disk creates directories and files."""
+    db_file = tmp_path / "sub" / "dir" / "test.db"
+    storage = MessageStorage(db_file)
+    assert db_file.exists()
+    storage.close()
+
+
+def test_save_and_get_message(memory_storage: MessageStorage) -> None:
+    """Test saving a new message and retrieving it by ID."""
+    msg = Message(
+        direction=MessageDirection.OUTBOUND,
+        sender="Snippen",
+        recipient="+4799887766",
+        body="Din booking er bekreftet.",
+        status=MessageStatus.PENDING,
+    )
+    saved = memory_storage.save_message(msg)
+    assert saved.id is not None
+    assert saved.id > 0
+    assert saved.created_at is not None
+    assert saved.modified_at is not None
+
+    retrieved = memory_storage.get_message(saved.id)
+    assert retrieved is not None
+    assert retrieved.id == saved.id
+    assert retrieved.direction == MessageDirection.OUTBOUND
+    assert retrieved.sender == "Snippen"
+    assert retrieved.recipient == "+4799887766"
+    assert retrieved.body == "Din booking er bekreftet."
+    assert retrieved.status == MessageStatus.PENDING
+    assert retrieved.created_at.tzinfo == UTC
+    assert retrieved.modified_at.tzinfo == UTC
+
+
+def test_get_nonexistent_message(memory_storage: MessageStorage) -> None:
+    """Test retrieving a non-existent message returns None."""
+    assert memory_storage.get_message(99999) is None
+
+
+def test_update_existing_message_via_save(memory_storage: MessageStorage) -> None:
+    """Test updating an already saved message updates modified_at."""
+    msg = Message(
+        direction=MessageDirection.OUTBOUND,
+        sender="Snippen",
+        recipient="+4799887766",
+        body="Initial",
+        status=MessageStatus.PENDING,
+    )
+    saved = memory_storage.save_message(msg)
+    initial_modified_at = saved.modified_at
+
+    time.sleep(0.01)
+    saved.body = "Updated body"
+    saved.status = MessageStatus.SENT
+    saved.modem_message_id = "modem-123"
+
+    updated = memory_storage.save_message(saved)
+    assert updated.id == saved.id
+    assert updated.body == "Updated body"
+    assert updated.status == MessageStatus.SENT
+    assert updated.modem_message_id == "modem-123"
+    assert updated.modified_at >= initial_modified_at
+
+    fetched = memory_storage.get_message(saved.id)
+    assert fetched is not None
+    assert fetched.body == "Updated body"
+    assert fetched.status == MessageStatus.SENT
+    assert fetched.modem_message_id == "modem-123"
+
+
+def test_update_message_status(memory_storage: MessageStorage) -> None:
+    """Test helper method update_message_status."""
+    msg = Message(
+        direction=MessageDirection.OUTBOUND,
+        sender="Snippen",
+        recipient="+4799887766",
+        body="Testing status update",
+        status=MessageStatus.PENDING,
+    )
+    saved = memory_storage.save_message(msg)
+    assert saved.id is not None
+
+    updated = memory_storage.update_message_status(
+        saved.id,
+        status=MessageStatus.FAILED,
+        error_message="Modem timed out",
+    )
+    assert updated is not None
+    assert updated.status == MessageStatus.FAILED
+    assert updated.error_message == "Modem timed out"
+
+    # Non-existent ID returns None
+    assert memory_storage.update_message_status(999, MessageStatus.SENT) is None
+
+
+def test_list_messages_and_filtering(memory_storage: MessageStorage) -> None:
+    """Test listing messages with filtering and pagination."""
+    memory_storage.save_message(
+        Message(
+            direction=MessageDirection.OUTBOUND,
+            sender="Snippen",
+            recipient="+4711111111",
+            body="Out 1",
+            status=MessageStatus.SENT,
+        )
+    )
+    memory_storage.save_message(
+        Message(
+            direction=MessageDirection.OUTBOUND,
+            sender="Snippen",
+            recipient="+4722222222",
+            body="Out 2",
+            status=MessageStatus.PENDING,
+        )
+    )
+    memory_storage.save_message(
+        Message(
+            direction=MessageDirection.INBOUND,
+            sender="+4733333333",
+            recipient="Snippen",
+            body="In 1",
+            status=MessageStatus.RECEIVED,
+        )
+    )
+
+    # All messages
+    all_msgs = memory_storage.list_messages()
+    assert len(all_msgs) == 3
+
+    # Filter by status
+    sent_msgs = memory_storage.list_messages(status=MessageStatus.SENT)
+    assert len(sent_msgs) == 1
+    assert sent_msgs[0].recipient == "+4711111111"
+
+    # Filter by direction
+    inbound_msgs = memory_storage.list_messages(direction=MessageDirection.INBOUND)
+    assert len(inbound_msgs) == 1
+    assert inbound_msgs[0].sender == "+4733333333"
+
+    # Pagination
+    paged = memory_storage.list_messages(limit=2, offset=1)
+    assert len(paged) == 2
+
+
+def test_delete_message(memory_storage: MessageStorage) -> None:
+    """Test deleting messages by ID."""
+    msg = memory_storage.save_message(
+        Message(
+            direction=MessageDirection.INBOUND,
+            sender="+4711223344",
+            recipient="Snippen",
+            body="Delete me",
+            status=MessageStatus.RECEIVED,
+        )
+    )
+    assert msg.id is not None
+    assert memory_storage.delete_message(msg.id) is True
+    assert memory_storage.get_message(msg.id) is None
+    assert memory_storage.delete_message(msg.id) is False
+
+
+def test_count_messages(memory_storage: MessageStorage) -> None:
+    """Test counting messages with filters."""
+    assert memory_storage.count_messages() == 0
+
+    memory_storage.save_message(
+        Message(
+            direction=MessageDirection.OUTBOUND,
+            sender="Snippen",
+            recipient="+47111",
+            body="1",
+            status=MessageStatus.PENDING,
+        )
+    )
+    memory_storage.save_message(
+        Message(
+            direction=MessageDirection.OUTBOUND,
+            sender="Snippen",
+            recipient="+47222",
+            body="2",
+            status=MessageStatus.SENT,
+        )
+    )
+
+    assert memory_storage.count_messages() == 2
+    assert memory_storage.count_messages(status=MessageStatus.PENDING) == 1
+    assert memory_storage.count_messages(direction=MessageDirection.INBOUND) == 0
+
+
+def test_persistence_survives_restart(tmp_path: Path) -> None:
+    """Test that message data persists to disk and survives service/storage restart."""
+    db_file = tmp_path / "persistent_messages.db"
+
+    # First session - write messages
+    storage1 = MessageStorage(db_file)
+    msg1 = storage1.save_message(
+        Message(
+            direction=MessageDirection.OUTBOUND,
+            sender="Snippen",
+            recipient="+4790000000",
+            body="Persistent SMS content",
+            status=MessageStatus.QUEUED,
+        )
+    )
+    msg2 = storage1.save_message(
+        Message(
+            direction=MessageDirection.INBOUND,
+            sender="+4791111111",
+            recipient="Snippen",
+            body="Persistent reply content",
+            status=MessageStatus.RECEIVED,
+        )
+    )
+    msg1_id = msg1.id
+    msg2_id = msg2.id
+    storage1.close()
+
+    # Second session - simulate gateway restart and reload from database file
+    storage2 = MessageStorage(db_file)
+    assert storage2.count_messages() == 2
+
+    reloaded_msg1 = storage2.get_message(msg1_id)  # type: ignore[arg-type]
+    assert reloaded_msg1 is not None
+    assert reloaded_msg1.body == "Persistent SMS content"
+    assert reloaded_msg1.status == MessageStatus.QUEUED
+    assert reloaded_msg1.direction == MessageDirection.OUTBOUND
+
+    reloaded_msg2 = storage2.get_message(msg2_id)  # type: ignore[arg-type]
+    assert reloaded_msg2 is not None
+    assert reloaded_msg2.body == "Persistent reply content"
+    assert reloaded_msg2.status == MessageStatus.RECEIVED
+    assert reloaded_msg2.direction == MessageDirection.INBOUND
+
+    storage2.close()
+
+
+def test_context_manager(tmp_path: Path) -> None:
+    """Test MessageStorage context manager usage."""
+    db_file = tmp_path / "ctx.db"
+    with MessageStorage(db_file) as storage:
+        storage.save_message(
+            Message(
+                direction=MessageDirection.OUTBOUND,
+                sender="Snippen",
+                recipient="+4799999999",
+                body="Context test",
+                status=MessageStatus.PENDING,
+            )
+        )
+        assert storage.count_messages() == 1


### PR DESCRIPTION
Closes #5

### Summary of Changes
- Implemented `Message`, `MessageDirection`, and `MessageStatus` domain models with ISO-8601 UTC timestamp tracking (`created_at`, `modified_at`).
- Implemented `MessageStorage` repository using embedded SQLite with WAL journal mode, providing full persistence across service restarts without external database dependencies.
- Added configurable `database_path` to `GatewayConfig` (`SNIPPEN_SMS_DATABASE_PATH`) and integrated `MessageStorage` directly into `GatewayService`.
- Added unit and integration tests covering CRUD operations, filtering, pagination, and restart survival in `tests/test_storage.py`.
- Updated documentation (`README.md`, `DEV_README.md`, `docs/architecture.md`) and bumped version to `0.3.0` in `CHANGELOG.md`.