### PR TITLE
(#28) Booking context resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-08-30
+
+### Added
+- Dynamic booking context resolution for incoming SMS messages (`#28`).
+- Domain model `Booking` with formatted Norwegian presentation (`format_summary`) and timestamp tracking (`#28`).
+- Domain model `ConversationContext` and `ConversationState` enum (`IDLE`, `AWAITING_SELECTION`, `RESOLVED`) (`#28`).
+- Core resolution engine `BookingContextResolver` supporting automatic unambiguous single-booking association, multi-booking disambiguation prompts, and active session TTL continuation (`#28`).
+- Robust natural-language and numeric selection parsing (`1`, `2`, `Nr 1`, `#2`, `første`, etc.) without rigid SMS commands (`#28`).
+- SQLite database migration `0004_messages_booking_context.sql` adding `booking_id` and `conversation_id` columns to `messages` and creating `conversation_contexts` tracking table (`#28`).
+- Persistence methods `get_conversation_context`, `save_conversation_context`, `delete_conversation_context`, and query helpers `list_messages_by_booking` and `list_messages_by_phone` in `MessageStorage` (`#28`).
+- Client method `SnippenClient.fetch_bookings_for_phone()` for querying active reservations by phone number (`#28`).
+- Inbound sync reporting transmitting resolved `booking_id` and `conversation_id` payloads to Snippen backend (`#28`).
+- Integration of `BookingContextResolver` in `GatewayService` message ingestion loop and `SyncService` (`#28`).
+- Configuration options `booking_resolution_enabled` and `conversation_ttl_seconds` in `GatewayConfig` (`#28`).
+- Comprehensive unit and integration test suite in `tests/test_context.py` and extended storage/client/gateway tests (`#28`).
+- Architecture documentation, sequence diagram, and WordPress REST API specification updated with context resolution endpoints (`#28`).
+
 ## [0.12.0] - 2026-08-30
 
 ### Added

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -22,6 +22,7 @@ snippen-sms-service/
 │       ├── __init__.py       # Package version & exports
 │       ├── client.py         # Snippen API HTTP client & error handling
 │       ├── config.py         # Gateway configuration settings
+│       ├── context.py        # Booking context resolution & conversational session management
 │       ├── gateway.py        # GatewayService lifecycle, send/receive orchestration & run loop
 │       ├── main.py           # Entry point & CLI runner
 │       ├── migrations/       # SQLite database migration system
@@ -41,6 +42,7 @@ snippen-sms-service/
 │   ├── conftest.py           # Pytest fixtures
 │   ├── test_build_release.py # Release build & checksum calculation tests
 │   ├── test_client.py        # SnippenClient HTTP client tests
+│   ├── test_context.py       # Booking context resolution & dialogue session tests
 │   ├── test_format.py        # Formatter tests
 │   ├── test_gateway.py       # GatewayService lifecycle & provider integration tests
 │   ├── test_main.py          # Unit tests

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The gateway service can be configured via CLI flags or environment variables:
 | Sync Interval | `SNIPPEN_SMS_SYNC_INTERVAL` | `5.0` | Synchronization interval in seconds |
 | Sync Timeout | `SNIPPEN_SMS_SYNC_TIMEOUT` | `10.0` | HTTP request timeout in seconds |
 | Sync Enabled | `SNIPPEN_SMS_SYNC_ENABLED` | `true` | Enable/disable automatic Snippen synchronization |
+| Booking Resolution | `SNIPPEN_SMS_BOOKING_RESOLUTION_ENABLED` | `true` | Enable automatic booking context resolution for incoming SMS |
+| Conversation TTL | `SNIPPEN_SMS_CONVERSATION_TTL_SECONDS` | `7200.0` | Active dialogue session window in seconds (2 hours) |
 | GitHub Repo | `SNIPPEN_SMS_GITHUB_REPO` | `jonasfh/snippen-sms-service` | Target repository for software updates |
 | Startup Update Check | `SNIPPEN_SMS_CHECK_UPDATES_ON_STARTUP` | `true` | Check GitHub Releases on service start |
 | Auto Update Check | `SNIPPEN_SMS_AUTO_UPDATE_CHECK` | `true` | Enable periodic background update checks |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,7 +228,20 @@ erDiagram
         string status
         string modem_message_id
         string external_id
+        string booking_id
+        int conversation_id
         string error_message
+        string created_at
+        string modified_at
+    }
+    conversation_contexts {
+        int id PK
+        string phone_number
+        string active_booking_id
+        string pending_booking_ids
+        int pending_message_id
+        string state
+        string last_activity_at
         string created_at
         string modified_at
     }
@@ -242,8 +255,46 @@ erDiagram
 
 - **Persistence Layer (`MessageStorage`)**: Built on Python standard library `sqlite3` using Write-Ahead Logging (`WAL`) mode for robust, concurrent reads and writes without external database server dependencies.
 - **Timestamp Tracking**: Every record maintains ISO-8601 UTC `created_at` and `modified_at` timestamps for auditing, synchronization, and retry workflows.
-- **External Identifier Tracking**: The `external_id` column indexes external identifiers assigned by Snippen Booking, enabling idempotent outbox polling and delivery status reconciliation without duplicates.
+- **External & Booking Tracking**: The `external_id` column indexes external identifiers assigned by Snippen Booking, while `booking_id` and `conversation_id` associate messages with reservation lifecycles and ongoing dialogue threads.
+- **Conversation State Tracking (`conversation_contexts`)**: Tracks active booking context, pending booking selections, and state transitions for each customer phone number.
 - **Migration Management (`MigrationRunner`)**: Sequential SQL migration scripts managed atomically with `schema_migrations` tracking, SHA-256 checksum verification, `PRAGMA user_version` synchronization, and automatic execution upon service initialization.
+
+---
+
+## Booking Context Resolution & Conversation Management
+
+When guests reply or send inquiries via SMS, `snippen-sms-service` dynamically identifies the applicable Snippen booking without requiring users to type complicated reference codes or IDs:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Guest as Customer / Guest
+    participant GW as SMS Gateway / ContextResolver
+    participant DB as SQLite Storage
+    participant API as Snippen Booking API
+
+    alt Case 1: Single Active Booking (Unambiguous)
+        Guest->>GW: "Hva er koden til døra?"
+        GW->>API: GET /wp-json/snippen/v1/sms/bookings?phone=+479...
+        API-->>GW: [{id: "105", resource: "Badstue", start_time: "..."}]
+        GW->>DB: Save message with booking_id="105", state=RESOLVED
+    else Case 2: Multiple Active Bookings (Ambiguous Selection Flow)
+        Guest->>GW: "Ehh, jeg trenger noen bord. Er det mulig å få utvask?"
+        GW->>API: GET /wp-json/snippen/v1/sms/bookings?phone=+479...
+        API-->>GW: [{id: "105", 15.12.2026}, {id: "109", 05.01.2027}]
+        GW->>DB: Set state=AWAITING_SELECTION, pending_ids=["105", "109"]
+        GW->>Guest: "Du har flere reservasjoner:\n1. 15.12.2026 16:00 (Badstue)\n2. 05.01.2027 11:00 (Felleslokale)\nSvar med tall (1 el 2)..."
+        Guest->>GW: "1"
+        GW->>DB: Update pending & reply messages with booking_id="105", state=RESOLVED
+    end
+```
+
+### Context Resolution Capabilities
+1. **Zero Booking ID Friction**: Users do not need to memorize or write booking IDs. Context is derived from customer phone numbers and existing reservation schedules.
+2. **Automatic Association**: If the user has a single active booking, incoming messages are immediately associated with it.
+3. **Interactive Multi-Booking Disambiguation**: When multiple reservations exist, the gateway sends a clear, natural-language prompt listing candidate bookings and lets the user reply with the option number (`1`, `2`, `Nr 1`, `første`).
+4. **Active Session Continuation**: Once resolved, subsequent messages within a configurable session window (default 2 hours) automatically inherit the active booking context.
+5. **Two-Way Synchronization**: Resolved `booking_id` and `conversation_id` are reported directly to the Snippen Booking backend during inbox sync.
 
 ---
 

--- a/docs/snippen_booking_api_spec.md
+++ b/docs/snippen_booking_api_spec.md
@@ -128,7 +128,7 @@ Base Namespace: `/wp-json/snippen/v1/sms`
 ---
 
 ### 3. `POST /wp-json/snippen/v1/sms/inbox`
-**Description**: Called by the gateway to report newly received inbound SMS messages (guest replies, confirmations, commands).
+**Description**: Called by the gateway to report newly received inbound SMS messages (guest replies, confirmations, commands) along with resolved booking context.
 
 - **Method**: `POST`
 - **Headers**:
@@ -143,6 +143,8 @@ Base Namespace: `/wp-json/snippen/v1/sms`
         "sender": "+4791234567",
         "recipient": "snippen-sms-service",
         "body": "JA",
+        "booking_id": "105",
+        "conversation_id": 3,
         "received_at": "2026-08-30T10:15:30Z",
         "modem_message_id": "modem-in-99"
       }
@@ -160,9 +162,43 @@ Base Namespace: `/wp-json/snippen/v1/sms`
 
 ---
 
+### 4. `GET /wp-json/snippen/v1/sms/bookings`
+**Description**: Polled by the gateway to retrieve active/upcoming bookings for a specific customer phone number when resolving ambiguous incoming SMS context.
+
+- **Method**: `GET`
+- **Query Parameters**:
+  - `phone`: Customer telephone number in E.164 format (e.g. `+4791234567`)
+- **Headers**:
+  - `Accept: application/json`
+  - `Authorization: Bearer <token>`
+- **Response**: `200 OK`
+  ```json
+  {
+    "bookings": [
+      {
+        "id": "105",
+        "customer_name": "Ola Nordmann",
+        "start_time": "2026-12-15T16:00:00Z",
+        "end_time": "2026-12-15T18:00:00Z",
+        "resource_name": "Badstue",
+        "status": "confirmed"
+      },
+      {
+        "id": "109",
+        "customer_name": "Ola Nordmann",
+        "start_time": "2027-01-05T11:00:00Z",
+        "resource_name": "Felleslokale",
+        "status": "confirmed"
+      }
+    ]
+  }
+  ```
+
+---
+
 ## Ready-to-use Implementation Tasks for `snippen-booking`
 
-Below are three copy-pasteable tasks/issues to file in the `snippen-booking` WordPress plugin repository.
+Below are four copy-pasteable tasks/issues to file in the `snippen-booking` WordPress plugin repository.
 
 ---
 
@@ -218,3 +254,20 @@ Receive incoming SMS messages from the SMS Gateway and connect them with booking
   - Returns `{"success": true, "processed_ids": [<gateway_id>, ...]}`.
 - [ ] Deduplicate incoming messages using `gateway_id` or `modem_message_id`.
 - [ ] Tests verifying inbound message handling and booking status transitions.
+
+---
+
+### Task 4: [Feature] Implement Customer Bookings Lookup REST Route for Context Resolution
+
+#### Title:
+`[Feature] Implement GET /wp-json/snippen/v1/sms/bookings for Context Resolution`
+
+#### Description:
+Expose customer active/upcoming bookings by phone number so the SMS Gateway can resolve conversation context.
+
+#### Acceptance Criteria:
+- [ ] Register `GET /wp-json/snippen/v1/sms/bookings`:
+  - Accepts query parameter `?phone=<e164>`.
+  - Queries active, upcoming, or recent bookings for that phone number.
+  - Returns `{"bookings": [{"id": "<id>", "customer_name": "<name>", "start_time": "<iso8601>", "end_time": "<iso8601>", "resource_name": "<name>", "status": "confirmed"}]}`.
+- [ ] Tests verifying querying bookings by phone number and returning empty list when none match.

--- a/src/snippen_sms/__init__.py
+++ b/src/snippen_sms/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 from snippen_sms.client import (
     SnippenApiError,
@@ -12,9 +12,21 @@ from snippen_sms.client import (
     SnippenNetworkError,
 )
 from snippen_sms.config import GatewayConfig
+from snippen_sms.context import (
+    BookingContextResolver,
+    ContextResolutionResult,
+    ResolutionStatus,
+)
 from snippen_sms.gateway import GatewayService
 from snippen_sms.migrations import Migration, MigrationError, MigrationRunner
-from snippen_sms.models import Message, MessageDirection, MessageStatus
+from snippen_sms.models import (
+    Booking,
+    ConversationContext,
+    ConversationState,
+    Message,
+    MessageDirection,
+    MessageStatus,
+)
 from snippen_sms.providers import (
     IncomingMessage,
     InMemorySmsProvider,
@@ -36,6 +48,11 @@ from snippen_sms.updater import (
 )
 
 __all__ = [
+    "Booking",
+    "BookingContextResolver",
+    "ContextResolutionResult",
+    "ConversationContext",
+    "ConversationState",
     "GatewayConfig",
     "GatewayService",
     "InMemorySmsProvider",
@@ -50,6 +67,7 @@ __all__ = [
     "MockSMSProvider",
     "MockSmsProvider",
     "ReleaseInfo",
+    "ResolutionStatus",
     "SendResult",
     "SmsProvider",
     "SnippenApiError",

--- a/src/snippen_sms/client.py
+++ b/src/snippen_sms/client.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import json
 import logging
 import urllib.error
+import urllib.parse
 import urllib.request
+from datetime import UTC, datetime
 from typing import Any
 
 from snippen_sms import __version__
-from snippen_sms.models import Message
+from snippen_sms.models import Booking, Message
 
 logger = logging.getLogger("snippen_sms.client")
 
@@ -57,9 +59,14 @@ class SnippenClient:
         method: str,
         path: str,
         payload: dict[str, Any] | None = None,
+        query_params: dict[str, str] | None = None,
     ) -> Any:
         """Execute HTTP request against Snippen API with auth headers and error handling."""
         url = self._get_endpoint_url(path)
+        if query_params:
+            encoded_params = urllib.parse.urlencode(query_params)
+            url = f"{url}?{encoded_params}"
+
         headers = {
             "Accept": "application/json",
             "User-Agent": f"snippen-sms-service/{__version__}",
@@ -135,6 +142,56 @@ class SnippenClient:
                 return messages
         return []
 
+    def fetch_bookings_for_phone(self, phone_number: str) -> list[Booking]:
+        """Fetch active/upcoming bookings associated with a specific customer phone number."""
+        data = self._request("GET", "bookings", query_params={"phone": phone_number})
+        raw_list: list[dict[str, Any]] = []
+        if isinstance(data, list):
+            raw_list = data
+        elif isinstance(data, dict):
+            items = data.get("bookings") or data.get("items") or data.get("data")
+            if isinstance(items, list):
+                raw_list = items
+
+        bookings: list[Booking] = []
+        for item in raw_list:
+            try:
+                booking_id = str(item.get("id") or item.get("booking_id") or "").strip()
+                if not booking_id:
+                    continue
+
+                start_raw = item.get("start_time") or item.get("date") or item.get("starts_at")
+                if not start_raw:
+                    continue
+                start_dt = datetime.fromisoformat(str(start_raw))
+                if start_dt.tzinfo is None:
+                    start_dt = start_dt.replace(tzinfo=UTC)
+
+                end_dt: datetime | None = None
+                end_raw = item.get("end_time") or item.get("ends_at")
+                if end_raw:
+                    end_dt = datetime.fromisoformat(str(end_raw))
+                    if end_dt.tzinfo is None:
+                        end_dt = end_dt.replace(tzinfo=UTC)
+
+                bookings.append(
+                    Booking(
+                        id=booking_id,
+                        customer_phone=phone_number,
+                        customer_name=item.get("customer_name") or item.get("name"),
+                        start_time=start_dt,
+                        end_time=end_dt,
+                        resource_name=item.get("resource_name")
+                        or item.get("resource")
+                        or item.get("room"),
+                        status=str(item.get("status") or "confirmed"),
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to parse booking record %s: %s", item, exc)
+
+        return bookings
+
     def report_inbound_messages(self, messages: list[Message]) -> list[int]:
         """Report received inbound SMS messages to Snippen.
 
@@ -150,6 +207,8 @@ class SnippenClient:
                     "sender": msg.sender,
                     "recipient": msg.recipient,
                     "body": msg.body,
+                    "booking_id": msg.booking_id,
+                    "conversation_id": msg.conversation_id,
                     "received_at": msg.created_at.isoformat(),
                     "modem_message_id": msg.modem_message_id,
                 }

--- a/src/snippen_sms/config.py
+++ b/src/snippen_sms/config.py
@@ -25,6 +25,8 @@ class GatewayConfig:
     sync_interval_seconds: float = 5.0
     sync_timeout_seconds: float = 10.0
     sync_enabled: bool = True
+    booking_resolution_enabled: bool = True
+    conversation_ttl_seconds: float = 7200.0
 
     @classmethod
     def from_env(cls) -> GatewayConfig:
@@ -34,6 +36,9 @@ class GatewayConfig:
         )
         auto_check_env = os.getenv("SNIPPEN_SMS_AUTO_UPDATE_CHECK", "true").strip().lower()
         sync_enabled_env = os.getenv("SNIPPEN_SMS_SYNC_ENABLED", "true").strip().lower()
+        booking_res_env = (
+            os.getenv("SNIPPEN_SMS_BOOKING_RESOLUTION_ENABLED", "true").strip().lower()
+        )
 
         api_url = os.getenv("SNIPPEN_SMS_API_URL") or os.getenv("SNIPPEN_API_URL")
         api_token = os.getenv("SNIPPEN_SMS_API_TOKEN") or os.getenv("SNIPPEN_API_TOKEN")
@@ -56,4 +61,8 @@ class GatewayConfig:
             sync_interval_seconds=float(os.getenv("SNIPPEN_SMS_SYNC_INTERVAL", "5.0")),
             sync_timeout_seconds=float(os.getenv("SNIPPEN_SMS_SYNC_TIMEOUT", "10.0")),
             sync_enabled=sync_enabled_env in ("true", "1", "yes"),
+            booking_resolution_enabled=booking_res_env in ("true", "1", "yes"),
+            conversation_ttl_seconds=float(
+                os.getenv("SNIPPEN_SMS_CONVERSATION_TTL_SECONDS", "7200.0")
+            ),
         )

--- a/src/snippen_sms/context.py
+++ b/src/snippen_sms/context.py
@@ -1,0 +1,346 @@
+"""Booking context resolution and conversation session management."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+from snippen_sms.client import SnippenClient
+from snippen_sms.models import (
+    Booking,
+    ConversationContext,
+    ConversationState,
+    Message,
+)
+from snippen_sms.storage import MessageStorage
+
+logger = logging.getLogger("snippen_sms.context")
+
+SELECTION_PATTERN = re.compile(
+    r"^\s*(?:nr\.?|nummer|valg|booking|alternativ|#)?\s*(\d+)\.?\s*$",
+    re.IGNORECASE,
+)
+
+ORDINAL_MAP = {
+    "første": 1,
+    "den første": 1,
+    "1ste": 1,
+    "andre": 2,
+    "den andre": 2,
+    "2dre": 2,
+    "tredje": 3,
+    "den tredje": 3,
+    "3dje": 3,
+    "fjerde": 4,
+    "den fjerde": 4,
+    "femte": 5,
+    "den femte": 5,
+}
+
+
+class ResolutionStatus(str, Enum):
+    """Outcome of resolving booking context for an SMS."""
+
+    RESOLVED = "resolved"
+    PROMPT_SENT = "prompt_sent"
+    UNRESOLVED = "unresolved"
+    INVALID_SELECTION = "invalid_selection"
+
+
+@dataclass
+class ContextResolutionResult:
+    """Result returned by BookingContextResolver."""
+
+    status: ResolutionStatus
+    message: Message
+    booking_id: str | None = None
+    context: ConversationContext | None = None
+    prompt_text: str | None = None
+    candidate_bookings: list[Booking] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert result to dictionary representation."""
+        return {
+            "status": self.status.value,
+            "message_id": self.message.id,
+            "booking_id": self.booking_id,
+            "prompt_text": self.prompt_text,
+            "candidate_count": len(self.candidate_bookings),
+        }
+
+
+class BookingContextResolver:
+    """Resolves incoming SMS messages to appropriate Snippen bookings."""
+
+    def __init__(
+        self,
+        storage: MessageStorage,
+        client: SnippenClient | None = None,
+        conversation_ttl_seconds: float = 7200.0,
+        service_name: str = "snippen-sms-service",
+    ) -> None:
+        self.storage = storage
+        self.client = client
+        self.conversation_ttl_seconds = conversation_ttl_seconds
+        self.service_name = service_name
+
+    @staticmethod
+    def parse_selection(text: str, max_options: int) -> int | None:
+        """Parse user reply text to identify selected option index (1-based).
+
+        Supports numeric strings ('1', '2', 'Nr 1', '#2', 'valg 1') and Norwegian ordinals.
+        """
+        clean = text.strip().lower()
+        if not clean:
+            return None
+
+        # Check numeric regex match
+        match = SELECTION_PATTERN.match(clean)
+        if match:
+            try:
+                choice = int(match.group(1))
+                if 1 <= choice <= max_options:
+                    return choice
+            except ValueError:
+                pass
+
+        # Check ordinal mappings
+        if clean in ORDINAL_MAP:
+            choice = ORDINAL_MAP[clean]
+            if 1 <= choice <= max_options:
+                return choice
+
+        return None
+
+    @staticmethod
+    def format_selection_prompt(bookings: list[Booking]) -> str:
+        """Format friendly Norwegian prompt asking user to select booking."""
+        lines = [
+            "Du har flere reservasjoner registrert hos oss:",
+        ]
+        for idx, b in enumerate(bookings, start=1):
+            lines.append(f"{idx}. {b.format_summary()}")
+        lines.append(
+            "Vennligst svar med tallet (f.eks. 1 eller 2) for reservasjonen henvendelsen gjelder."
+        )
+        return "\n".join(lines)
+
+    def _is_session_expired(self, context: ConversationContext, current_time: datetime) -> bool:
+        """Check if active conversation session has exceeded TTL."""
+        elapsed = (current_time - context.last_activity_at).total_seconds()
+        return elapsed > self.conversation_ttl_seconds
+
+    def resolve_incoming_message(
+        self,
+        message: Message,
+        available_bookings: list[Booking] | None = None,
+    ) -> ContextResolutionResult:
+        """Resolve booking context for an incoming SMS message.
+
+        Handles:
+        1. Ongoing selection prompt (user replying with option number).
+        2. Active conversation context continuation (within TTL).
+        3. Unambiguous single booking (automatic association).
+        4. Multiple candidate bookings (initiating selection prompt).
+        5. Zero bookings (graceful handling without error).
+        """
+        sender = message.sender.strip()
+        now = message.created_at or datetime.now(UTC)
+
+        # Retrieve or initialize conversation context
+        context = self.storage.get_conversation_context(sender)
+        if context is None:
+            context = ConversationContext(
+                phone_number=sender,
+                state=ConversationState.IDLE,
+                last_activity_at=now,
+            )
+            context = self.storage.save_conversation_context(context)
+
+        # Handle expired context
+        if self._is_session_expired(context, now):
+            logger.debug("Conversation session for %s expired; resetting state to idle", sender)
+            context.state = ConversationState.IDLE
+            context.pending_booking_ids = []
+            context.pending_message_id = None
+            context.active_booking_id = None
+            context.last_activity_at = now
+            context = self.storage.save_conversation_context(context)
+
+        # 1. Check if user is replying to an active selection prompt
+        if context.state == ConversationState.AWAITING_SELECTION and context.pending_booking_ids:
+            choice = self.parse_selection(message.body, len(context.pending_booking_ids))
+            if choice is not None:
+                resolved_id = context.pending_booking_ids[choice - 1]
+                logger.info(
+                    "User %s selected booking %s (option %d)",
+                    sender,
+                    resolved_id,
+                    choice,
+                )
+
+                # Associate current message
+                message.booking_id = resolved_id
+                message.conversation_id = context.id
+                self.storage.save_message(message)
+
+                # Associate pending original message if recorded
+                if context.pending_message_id is not None:
+                    self.storage.update_message_booking_context(
+                        message_id=context.pending_message_id,
+                        booking_id=resolved_id,
+                        conversation_id=context.id,
+                    )
+                    logger.debug(
+                        "Associated pending message ID %s with booking %s",
+                        context.pending_message_id,
+                        resolved_id,
+                    )
+
+                # Transition context to resolved active state
+                context.state = ConversationState.RESOLVED
+                context.active_booking_id = resolved_id
+                context.pending_booking_ids = []
+                context.pending_message_id = None
+                context.last_activity_at = now
+                self.storage.save_conversation_context(context)
+
+                return ContextResolutionResult(
+                    status=ResolutionStatus.RESOLVED,
+                    message=message,
+                    booking_id=resolved_id,
+                    context=context,
+                )
+
+            logger.debug(
+                "Inbound message from %s during selection was not a valid option choice: '%s'",
+                sender,
+                message.body,
+            )
+
+        # 2. Check if user has an active resolved booking context within TTL
+        if context.state == ConversationState.RESOLVED and context.active_booking_id:
+            message.booking_id = context.active_booking_id
+            message.conversation_id = context.id
+            self.storage.save_message(message)
+
+            context.last_activity_at = now
+            self.storage.save_conversation_context(context)
+
+            logger.info(
+                "Associated message ID %s from %s with active booking %s",
+                message.id,
+                sender,
+                context.active_booking_id,
+            )
+            return ContextResolutionResult(
+                status=ResolutionStatus.RESOLVED,
+                message=message,
+                booking_id=context.active_booking_id,
+                context=context,
+            )
+
+        # 3. Fetch candidate bookings for sender
+        candidate_bookings: list[Booking] = []
+        if available_bookings is not None:
+            candidate_bookings = available_bookings
+        elif self.client is not None:
+            try:
+                candidate_bookings = self.client.fetch_bookings_for_phone(sender)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to fetch bookings for %s from Snippen client: %s", sender, exc
+                )
+                candidate_bookings = []
+
+        # Sort candidate bookings by start_time
+        candidate_bookings.sort(key=lambda b: b.start_time)
+
+        # Case A: 0 Bookings found
+        if not candidate_bookings:
+            logger.info("No active bookings found for sender %s", sender)
+            message.booking_id = None
+            message.conversation_id = context.id
+            self.storage.save_message(message)
+
+            context.state = ConversationState.IDLE
+            context.last_activity_at = now
+            self.storage.save_conversation_context(context)
+
+            return ContextResolutionResult(
+                status=ResolutionStatus.UNRESOLVED,
+                message=message,
+                booking_id=None,
+                context=context,
+            )
+
+        # Case B: Exactly 1 Booking found (unambiguous context)
+        if len(candidate_bookings) == 1:
+            single_booking = candidate_bookings[0]
+            resolved_id = single_booking.id
+            logger.info(
+                "Unambiguous single booking %s matched for sender %s",
+                resolved_id,
+                sender,
+            )
+
+            message.booking_id = resolved_id
+            message.conversation_id = context.id
+            self.storage.save_message(message)
+
+            context.state = ConversationState.RESOLVED
+            context.active_booking_id = resolved_id
+            context.pending_booking_ids = []
+            context.pending_message_id = None
+            context.last_activity_at = now
+            self.storage.save_conversation_context(context)
+
+            return ContextResolutionResult(
+                status=ResolutionStatus.RESOLVED,
+                message=message,
+                booking_id=resolved_id,
+                context=context,
+                candidate_bookings=candidate_bookings,
+            )
+
+        # Case C: Multiple (> 1) Bookings found (ambiguous context)
+        logger.info(
+            "Found %d candidate bookings for sender %s; initiating selection prompt",
+            len(candidate_bookings),
+            sender,
+        )
+        prompt_text = self.format_selection_prompt(candidate_bookings)
+
+        # Save incoming message
+        message.booking_id = None
+        message.conversation_id = context.id
+        saved_msg = self.storage.save_message(message)
+
+        # Update context to awaiting selection
+        context.state = ConversationState.AWAITING_SELECTION
+        context.pending_booking_ids = [b.id for b in candidate_bookings]
+        context.pending_message_id = saved_msg.id
+        context.last_activity_at = now
+        self.storage.save_conversation_context(context)
+
+        # Enqueue clarification prompt outbound SMS
+        self.storage.enqueue_outbox(
+            recipient=sender,
+            body=prompt_text,
+            sender=self.service_name,
+            conversation_id=context.id,
+        )
+        logger.info("Enqueued selection prompt to %s", sender)
+
+        return ContextResolutionResult(
+            status=ResolutionStatus.PROMPT_SENT,
+            message=saved_msg,
+            booking_id=None,
+            prompt_text=prompt_text,
+            candidate_bookings=candidate_bookings,
+            context=context,
+        )

--- a/src/snippen_sms/gateway.py
+++ b/src/snippen_sms/gateway.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from snippen_sms.client import SnippenClient
 from snippen_sms.config import GatewayConfig
+from snippen_sms.context import BookingContextResolver
 from snippen_sms.models import Message, MessageDirection, MessageStatus
 from snippen_sms.providers import get_provider
 from snippen_sms.providers.base import SmsProvider
@@ -30,6 +31,7 @@ class GatewayService:
         updater: SoftwareUpdater | None = None,
         client: SnippenClient | None = None,
         sync_service: SyncService | None = None,
+        resolver: BookingContextResolver | None = None,
     ) -> None:
         self.config = config or GatewayConfig()
         self.storage = storage or MessageStorage(self.config.database_path)
@@ -50,6 +52,18 @@ class GatewayService:
         else:
             self.client = None
 
+        if resolver is not None:
+            self.resolver = resolver
+        elif self.config.booking_resolution_enabled:
+            self.resolver = BookingContextResolver(
+                storage=self.storage,
+                client=self.client,
+                conversation_ttl_seconds=self.config.conversation_ttl_seconds,
+                service_name=self.config.service_name,
+            )
+        else:
+            self.resolver = None
+
         if sync_service is not None:
             self.sync_service = sync_service
         elif self.client is not None:
@@ -57,6 +71,7 @@ class GatewayService:
                 storage=self.storage,
                 client=self.client,
                 service_name=self.config.service_name,
+                resolver=self.resolver,
             )
         else:
             self.sync_service = None
@@ -104,6 +119,8 @@ class GatewayService:
             "total_messages": self.storage.count_messages(),
             "snippen_api_url": self.config.snippen_api_url,
             "sync_enabled": self.config.sync_enabled and (self.sync_service is not None),
+            "booking_resolution_enabled": self.config.booking_resolution_enabled
+            and (self.resolver is not None),
             "sync_interval_seconds": self.config.sync_interval_seconds,
             "last_sync_time": self._last_sync_time if self._last_sync_time > 0 else None,
             "last_sync_result": self._last_sync_result,
@@ -162,6 +179,8 @@ class GatewayService:
         recipient: str,
         body: str,
         sender: str | None = None,
+        booking_id: str | None = None,
+        conversation_id: int | None = None,
     ) -> Message:
         """Enqueue an outbound SMS into the persistent local outbox.
 
@@ -169,6 +188,8 @@ class GatewayService:
             recipient: Destination phone number.
             body: Text content of the SMS.
             sender: Optional originating sender ID (defaults to service name).
+            booking_id: Optional booking identifier.
+            conversation_id: Optional conversation session identifier.
 
         Returns:
             The saved pending Message instance.
@@ -179,6 +200,8 @@ class GatewayService:
             body=body,
             sender=sender_id,
             status=MessageStatus.PENDING,
+            booking_id=booking_id,
+            conversation_id=conversation_id,
         )
         logger.info("Enqueued message ID %s for %s to outbox", message.id, recipient)
         return message
@@ -242,6 +265,8 @@ class GatewayService:
         recipient: str,
         body: str,
         sender: str | None = None,
+        booking_id: str | None = None,
+        conversation_id: int | None = None,
     ) -> Message:
         """Enqueue an outbound message to the outbox and immediately attempt delivery.
 
@@ -249,11 +274,19 @@ class GatewayService:
             recipient: Destination phone number.
             body: Text content of the SMS.
             sender: Originating sender ID or service name.
+            booking_id: Optional booking identifier.
+            conversation_id: Optional conversation session identifier.
 
         Returns:
             The persisted Message record with updated delivery status.
         """
-        saved_msg = self.enqueue_outbox(recipient=recipient, body=body, sender=sender)
+        saved_msg = self.enqueue_outbox(
+            recipient=recipient,
+            body=body,
+            sender=sender,
+            booking_id=booking_id,
+            conversation_id=conversation_id,
+        )
         assert saved_msg.id is not None
 
         try:
@@ -292,7 +325,8 @@ class GatewayService:
         """Poll incoming SMS messages from the provider and persist them to storage.
 
         Deduplicates incoming messages using the provider's message identifier
-        to ensure messages are not ingested or processed repeatedly.
+        to ensure messages are not ingested or processed repeatedly, and resolves
+        booking context if resolver is enabled.
         """
         try:
             inbound_items = await self.provider.receive_sms()
@@ -327,7 +361,20 @@ class GatewayService:
                     created_at=item.received_at,
                 )
                 saved = self.storage.save_message(msg)
-                persisted_messages.append(saved)
+
+                # Resolve booking context if enabled
+                if self.resolver is not None and self.config.booking_resolution_enabled:
+                    try:
+                        self.resolver.resolve_incoming_message(saved)
+                    except Exception:
+                        logger.exception(
+                            "Failed to resolve booking context for inbound SMS ID %s",
+                            saved.id,
+                        )
+
+                # Fetch updated record with resolved context
+                refreshed = self.storage.get_message(saved.id) if saved.id is not None else saved
+                persisted_messages.append(refreshed or saved)
                 logger.info("Ingested inbound SMS ID %s from %s", saved.id, saved.sender)
             except Exception:
                 logger.exception(

--- a/src/snippen_sms/migrations/sql/0004_messages_booking_context.sql
+++ b/src/snippen_sms/migrations/sql/0004_messages_booking_context.sql
@@ -1,0 +1,23 @@
+-- Migration: 0004_messages_booking_context
+-- Description: Add booking_id and conversation_id columns to messages, and create conversation_contexts table
+
+ALTER TABLE messages ADD COLUMN booking_id TEXT;
+ALTER TABLE messages ADD COLUMN conversation_id INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_messages_booking_id ON messages(booking_id);
+CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
+
+CREATE TABLE IF NOT EXISTS conversation_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    phone_number TEXT NOT NULL UNIQUE,
+    active_booking_id TEXT,
+    pending_booking_ids TEXT,
+    pending_message_id INTEGER,
+    state TEXT NOT NULL DEFAULT 'idle',
+    last_activity_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    modified_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_conv_contexts_phone ON conversation_contexts(phone_number);
+CREATE INDEX IF NOT EXISTS idx_conv_contexts_state ON conversation_contexts(state);

--- a/src/snippen_sms/models.py
+++ b/src/snippen_sms/models.py
@@ -27,6 +27,105 @@ class MessageStatus(str, Enum):
     DELIVERED = "delivered"
 
 
+class ConversationState(str, Enum):
+    """State of an ongoing conversational context."""
+
+    IDLE = "idle"
+    AWAITING_SELECTION = "awaiting_selection"
+    RESOLVED = "resolved"
+
+
+@dataclass
+class Booking:
+    """Represents a Snippen booking record associated with a user."""
+
+    id: str
+    customer_phone: str
+    start_time: datetime
+    customer_name: str | None = None
+    end_time: datetime | None = None
+    resource_name: str | None = None
+    status: str = "confirmed"
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    modified_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        """Ensure datetimes have UTC timezone if naive."""
+        if self.start_time.tzinfo is None:
+            self.start_time = self.start_time.replace(tzinfo=UTC)
+        if self.end_time is not None and self.end_time.tzinfo is None:
+            self.end_time = self.end_time.replace(tzinfo=UTC)
+        if self.created_at.tzinfo is None:
+            self.created_at = self.created_at.replace(tzinfo=UTC)
+        if self.modified_at.tzinfo is None:
+            self.modified_at = self.modified_at.replace(tzinfo=UTC)
+
+    def format_summary(self) -> str:
+        """Format a human-readable booking summary for SMS presentation.
+
+        Example: '15.12.2026 kl. 16:00 (Badstue)' or '15.12.2026 kl. 16:00'.
+        """
+        # Format date as DD.MM.YYYY and time as HH:MM
+        date_str = self.start_time.strftime("%d.%m.%Y kl. %H:%M")
+        if self.resource_name:
+            return f"{date_str} ({self.resource_name})"
+        return date_str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert booking to dictionary representation."""
+        return {
+            "id": self.id,
+            "customer_phone": self.customer_phone,
+            "customer_name": self.customer_name,
+            "start_time": self.start_time.isoformat(),
+            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "resource_name": self.resource_name,
+            "status": self.status,
+            "created_at": self.created_at.isoformat(),
+            "modified_at": self.modified_at.isoformat(),
+        }
+
+
+@dataclass
+class ConversationContext:
+    """Represents the active conversation session for a phone number."""
+
+    phone_number: str
+    id: int | None = None
+    active_booking_id: str | None = None
+    pending_booking_ids: list[str] = field(default_factory=list)
+    pending_message_id: int | None = None
+    state: ConversationState = ConversationState.IDLE
+    last_activity_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    modified_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        """Validate and normalize fields."""
+        if isinstance(self.state, str) and not isinstance(self.state, ConversationState):
+            self.state = ConversationState(self.state)
+        if self.last_activity_at.tzinfo is None:
+            self.last_activity_at = self.last_activity_at.replace(tzinfo=UTC)
+        if self.created_at.tzinfo is None:
+            self.created_at = self.created_at.replace(tzinfo=UTC)
+        if self.modified_at.tzinfo is None:
+            self.modified_at = self.modified_at.replace(tzinfo=UTC)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert conversation context to dictionary representation."""
+        return {
+            "id": self.id,
+            "phone_number": self.phone_number,
+            "active_booking_id": self.active_booking_id,
+            "pending_booking_ids": self.pending_booking_ids,
+            "pending_message_id": self.pending_message_id,
+            "state": self.state.value,
+            "last_activity_at": self.last_activity_at.isoformat(),
+            "created_at": self.created_at.isoformat(),
+            "modified_at": self.modified_at.isoformat(),
+        }
+
+
 @dataclass
 class Message:
     """Represents an SMS message handled by the gateway."""
@@ -39,6 +138,8 @@ class Message:
     status: MessageStatus = MessageStatus.PENDING
     modem_message_id: str | None = None
     external_id: str | None = None
+    booking_id: str | None = None
+    conversation_id: int | None = None
     error_message: str | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     modified_at: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -65,6 +166,8 @@ class Message:
             "status": self.status.value,
             "modem_message_id": self.modem_message_id,
             "external_id": self.external_id,
+            "booking_id": self.booking_id,
+            "conversation_id": self.conversation_id,
             "error_message": self.error_message,
             "created_at": self.created_at.isoformat(),
             "modified_at": self.modified_at.isoformat(),

--- a/src/snippen_sms/storage.py
+++ b/src/snippen_sms/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 from datetime import UTC, datetime
@@ -10,13 +11,19 @@ from types import TracebackType
 from typing import Any, Self
 
 from snippen_sms.migrations.runner import MigrationRunner
-from snippen_sms.models import Message, MessageDirection, MessageStatus
+from snippen_sms.models import (
+    ConversationContext,
+    ConversationState,
+    Message,
+    MessageDirection,
+    MessageStatus,
+)
 
 logger = logging.getLogger("snippen_sms.storage")
 
 
 class MessageStorage:
-    """Persistent message repository backed by SQLite."""
+    """Persistent message and conversation repository backed by SQLite."""
 
     def __init__(
         self,
@@ -63,6 +70,10 @@ class MessageStorage:
         if modified_at_dt.tzinfo is None:
             modified_at_dt = modified_at_dt.replace(tzinfo=UTC)
 
+        keys = row.keys()
+        booking_id = row["booking_id"] if "booking_id" in keys else None
+        conversation_id = row["conversation_id"] if "conversation_id" in keys else None
+
         return Message(
             id=row["id"],
             direction=MessageDirection(row["direction"]),
@@ -72,7 +83,46 @@ class MessageStorage:
             status=MessageStatus(row["status"]),
             modem_message_id=row["modem_message_id"],
             external_id=row["external_id"],
+            booking_id=booking_id,
+            conversation_id=conversation_id,
             error_message=row["error_message"],
+            created_at=created_at_dt,
+            modified_at=modified_at_dt,
+        )
+
+    @staticmethod
+    def _row_to_conversation_context(row: sqlite3.Row) -> ConversationContext:
+        """Convert a database Row to a ConversationContext instance."""
+        last_activity_dt = datetime.fromisoformat(row["last_activity_at"])
+        if last_activity_dt.tzinfo is None:
+            last_activity_dt = last_activity_dt.replace(tzinfo=UTC)
+
+        created_at_dt = datetime.fromisoformat(row["created_at"])
+        if created_at_dt.tzinfo is None:
+            created_at_dt = created_at_dt.replace(tzinfo=UTC)
+
+        modified_at_dt = datetime.fromisoformat(row["modified_at"])
+        if modified_at_dt.tzinfo is None:
+            modified_at_dt = modified_at_dt.replace(tzinfo=UTC)
+
+        pending_ids_raw = row["pending_booking_ids"]
+        pending_booking_ids: list[str] = []
+        if pending_ids_raw:
+            try:
+                parsed = json.loads(pending_ids_raw)
+                if isinstance(parsed, list):
+                    pending_booking_ids = [str(x) for x in parsed]
+            except (json.JSONDecodeError, TypeError):
+                pending_booking_ids = []
+
+        return ConversationContext(
+            id=row["id"],
+            phone_number=row["phone_number"],
+            active_booking_id=row["active_booking_id"],
+            pending_booking_ids=pending_booking_ids,
+            pending_message_id=row["pending_message_id"],
+            state=ConversationState(row["state"]),
+            last_activity_at=last_activity_dt,
             created_at=created_at_dt,
             modified_at=modified_at_dt,
         )
@@ -90,8 +140,9 @@ class MessageStorage:
                     """
                     INSERT INTO messages (
                         direction, sender, recipient, body, status,
-                        modem_message_id, external_id, error_message, created_at, modified_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        modem_message_id, external_id, booking_id, conversation_id,
+                        error_message, created_at, modified_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         message.direction.value,
@@ -101,6 +152,8 @@ class MessageStorage:
                         message.status.value,
                         message.modem_message_id,
                         message.external_id,
+                        message.booking_id,
+                        message.conversation_id,
                         message.error_message,
                         message.created_at.isoformat(),
                         message.modified_at.isoformat(),
@@ -122,6 +175,8 @@ class MessageStorage:
                     status = ?,
                     modem_message_id = ?,
                     external_id = ?,
+                    booking_id = ?,
+                    conversation_id = ?,
                     error_message = ?,
                     modified_at = ?
                 WHERE id = ?
@@ -134,6 +189,8 @@ class MessageStorage:
                     message.status.value,
                     message.modem_message_id,
                     message.external_id,
+                    message.booking_id,
+                    message.conversation_id,
                     message.error_message,
                     message.modified_at.isoformat(),
                     message.id,
@@ -197,8 +254,9 @@ class MessageStorage:
         offset: int = 0,
         status: MessageStatus | str | None = None,
         direction: MessageDirection | str | None = None,
+        booking_id: str | None = None,
     ) -> list[Message]:
-        """List messages with optional status and direction filtering and pagination."""
+        """List messages with optional status, direction, and booking_id filtering and pagination."""
         query = "SELECT * FROM messages"
         conditions: list[str] = []
         params: list[Any] = []
@@ -213,6 +271,10 @@ class MessageStorage:
             conditions.append("direction = ?")
             params.append(dir_val)
 
+        if booking_id is not None:
+            conditions.append("booking_id = ?")
+            params.append(booking_id)
+
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
 
@@ -222,6 +284,21 @@ class MessageStorage:
         cursor = self.connection.execute(query, tuple(params))
         return [self._row_to_message(row) for row in cursor.fetchall()]
 
+    def list_messages_by_booking(self, booking_id: str, limit: int = 100) -> list[Message]:
+        """List messages associated with a specific booking ID."""
+        return self.list_messages(limit=limit, booking_id=booking_id)
+
+    def list_messages_by_phone(self, phone_number: str, limit: int = 100) -> list[Message]:
+        """List all inbound or outbound messages involving a specific phone number."""
+        query = """
+            SELECT * FROM messages
+            WHERE sender = ? OR recipient = ?
+            ORDER BY id DESC
+            LIMIT ?
+        """
+        cursor = self.connection.execute(query, (phone_number, phone_number, limit))
+        return [self._row_to_message(row) for row in cursor.fetchall()]
+
     def update_message_status(
         self,
         message_id: int,
@@ -229,6 +306,8 @@ class MessageStorage:
         error_message: str | None = None,
         modem_message_id: str | None = None,
         external_id: str | None = None,
+        booking_id: str | None = None,
+        conversation_id: int | None = None,
     ) -> Message | None:
         """Update the status and optional metadata of a message."""
         status_val = status.value if isinstance(status, MessageStatus) else str(status)
@@ -250,6 +329,14 @@ class MessageStorage:
             update_clauses.append("external_id = ?")
             params.append(external_id)
 
+        if booking_id is not None:
+            update_clauses.append("booking_id = ?")
+            params.append(booking_id)
+
+        if conversation_id is not None:
+            update_clauses.append("conversation_id = ?")
+            params.append(conversation_id)
+
         params.append(message_id)
         query = f"UPDATE messages SET {', '.join(update_clauses)} WHERE id = ?"
 
@@ -259,6 +346,21 @@ class MessageStorage:
                 return None
 
         return self.get_message(message_id)
+
+    def update_message_booking_context(
+        self,
+        message_id: int,
+        booking_id: str | None,
+        conversation_id: int | None = None,
+    ) -> Message | None:
+        """Update the booking and conversation context of a message."""
+        msg = self.get_message(message_id)
+        if msg is None:
+            return None
+        msg.booking_id = booking_id
+        if conversation_id is not None:
+            msg.conversation_id = conversation_id
+        return self.save_message(msg)
 
     def delete_message(self, message_id: int) -> bool:
         """Delete a message by its ID."""
@@ -273,6 +375,7 @@ class MessageStorage:
         self,
         status: MessageStatus | str | None = None,
         direction: MessageDirection | str | None = None,
+        booking_id: str | None = None,
     ) -> int:
         """Count total messages matching criteria."""
         query = "SELECT COUNT(*) FROM messages"
@@ -289,6 +392,10 @@ class MessageStorage:
             conditions.append("direction = ?")
             params.append(dir_val)
 
+        if booking_id is not None:
+            conditions.append("booking_id = ?")
+            params.append(booking_id)
+
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
 
@@ -303,6 +410,8 @@ class MessageStorage:
         sender: str = "snippen-sms-service",
         status: MessageStatus = MessageStatus.PENDING,
         external_id: str | None = None,
+        booking_id: str | None = None,
+        conversation_id: int | None = None,
     ) -> Message:
         """Add a new outbound message to the outbox."""
         message = Message(
@@ -312,6 +421,8 @@ class MessageStorage:
             body=body,
             status=status,
             external_id=external_id,
+            booking_id=booking_id,
+            conversation_id=conversation_id,
         )
         return self.save_message(message)
 
@@ -433,6 +544,96 @@ class MessageStorage:
     def count_inbox(self, status: MessageStatus | str | None = None) -> int:
         """Count messages in the inbox with optional status filter."""
         return self.count_messages(status=status, direction=MessageDirection.INBOUND)
+
+    # Conversation Context persistence methods
+    def get_conversation_context(self, phone_number: str) -> ConversationContext | None:
+        """Retrieve active conversation context for a phone number."""
+        cursor = self.connection.execute(
+            "SELECT * FROM conversation_contexts WHERE phone_number = ?",
+            (phone_number,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return self._row_to_conversation_context(row)
+
+    def save_conversation_context(self, context: ConversationContext) -> ConversationContext:
+        """Save or update a conversation context record."""
+        now = datetime.now(UTC)
+        conn = self.connection
+        pending_json = json.dumps(context.pending_booking_ids)
+
+        if context.id is None:
+            existing = self.get_conversation_context(context.phone_number)
+            if existing is not None:
+                context.id = existing.id
+
+        if context.id is None:
+            context.created_at = context.created_at or now
+            context.modified_at = now
+            with conn:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO conversation_contexts (
+                        phone_number, active_booking_id, pending_booking_ids,
+                        pending_message_id, state, last_activity_at, created_at, modified_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        context.phone_number,
+                        context.active_booking_id,
+                        pending_json,
+                        context.pending_message_id,
+                        context.state.value,
+                        context.last_activity_at.isoformat(),
+                        context.created_at.isoformat(),
+                        context.modified_at.isoformat(),
+                    ),
+                )
+                context.id = cursor.lastrowid
+            logger.debug(
+                "Saved new conversation context for %s with id=%s", context.phone_number, context.id
+            )
+            return context
+
+        context.modified_at = now
+        with conn:
+            conn.execute(
+                """
+                UPDATE conversation_contexts SET
+                    phone_number = ?,
+                    active_booking_id = ?,
+                    pending_booking_ids = ?,
+                    pending_message_id = ?,
+                    state = ?,
+                    last_activity_at = ?,
+                    modified_at = ?
+                WHERE id = ?
+                """,
+                (
+                    context.phone_number,
+                    context.active_booking_id,
+                    pending_json,
+                    context.pending_message_id,
+                    context.state.value,
+                    context.last_activity_at.isoformat(),
+                    context.modified_at.isoformat(),
+                    context.id,
+                ),
+            )
+        logger.debug(
+            "Updated conversation context for %s (id=%s)", context.phone_number, context.id
+        )
+        return context
+
+    def delete_conversation_context(self, phone_number: str) -> bool:
+        """Delete conversation context for a phone number."""
+        with self.connection:
+            cursor = self.connection.execute(
+                "DELETE FROM conversation_contexts WHERE phone_number = ?",
+                (phone_number,),
+            )
+            return cursor.rowcount > 0
 
     def close(self) -> None:
         """Close the database connection."""

--- a/src/snippen_sms/sync.py
+++ b/src/snippen_sms/sync.py
@@ -11,6 +11,7 @@ from snippen_sms.client import (
     SnippenClientError,
     SnippenNetworkError,
 )
+from snippen_sms.context import BookingContextResolver
 from snippen_sms.models import Message, MessageDirection
 from snippen_sms.storage import MessageStorage
 
@@ -25,10 +26,12 @@ class SyncService:
         storage: MessageStorage,
         client: SnippenClient,
         service_name: str = "snippen-sms-service",
+        resolver: BookingContextResolver | None = None,
     ) -> None:
         self.storage = storage
         self.client = client
         self.service_name = service_name
+        self.resolver = resolver
 
     def sync_inbox(self, limit: int = 100) -> list[int]:
         """Report unhandled received inbound SMS messages to Snippen and mark them processed.
@@ -40,8 +43,26 @@ class SyncService:
         if not unprocessed:
             return []
 
-        logger.debug("Reporting %d unprocessed inbound SMS to Snippen...", len(unprocessed))
-        acknowledged_ids = self.client.report_inbound_messages(unprocessed)
+        # Ensure context resolution is applied before reporting if resolver is available
+        if self.resolver is not None:
+            for msg in unprocessed:
+                if msg.booking_id is None and msg.direction == MessageDirection.INBOUND:
+                    try:
+                        self.resolver.resolve_incoming_message(msg)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "Booking context resolution failed for message %s during sync: %s",
+                            msg.id,
+                            exc,
+                        )
+
+        # Refresh messages after potential resolver modifications
+        fresh_unprocessed = [
+            self.storage.get_message(msg.id) or msg for msg in unprocessed if msg.id is not None
+        ]
+
+        logger.debug("Reporting %d unprocessed inbound SMS to Snippen...", len(fresh_unprocessed))
+        acknowledged_ids = self.client.report_inbound_messages(fresh_unprocessed)
 
         for msg_id in acknowledged_ids:
             self.storage.mark_inbox_processed(msg_id)
@@ -70,6 +91,9 @@ class SyncService:
             recipient = str(item.get("recipient") or item.get("to") or "").strip()
             body = str(item.get("body") or item.get("message") or item.get("text") or "").strip()
             sender = str(item.get("sender") or item.get("from") or "").strip() or self.service_name
+            booking_id = item.get("booking_id")
+            if booking_id is not None:
+                booking_id = str(booking_id).strip()
 
             if not recipient or not body:
                 logger.warning(
@@ -97,6 +121,7 @@ class SyncService:
                 body=body,
                 sender=sender,
                 external_id=external_id,
+                booking_id=booking_id,
             )
             enqueued.append(msg)
             logger.info(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,8 +94,52 @@ def test_fetch_pending_outbox_raw_list() -> None:
         assert items[0]["id"] == "msg-10"
 
 
+def test_fetch_bookings_for_phone_success() -> None:
+    """Test fetching customer bookings by phone number."""
+    client = SnippenClient(
+        api_url="https://vestreholmensameie.no/wp-json/snippen/v1/sms",
+        api_token="auth-tok",
+    )
+
+    mock_data = {
+        "bookings": [
+            {
+                "id": "b-1",
+                "customer_name": "Ola Nordmann",
+                "start_time": "2026-12-15T16:00:00Z",
+                "end_time": "2026-12-15T18:00:00Z",
+                "resource_name": "Badstue #1",
+                "status": "confirmed",
+            },
+            {
+                "id": "b-2",
+                "customer_name": "Ola Nordmann",
+                "start_time": "2027-01-05T11:00:00Z",
+                "resource_name": "Felleslokale",
+                "status": "confirmed",
+            },
+        ]
+    }
+
+    mock_resp = _create_mock_response(status=200, data=mock_data)
+
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+        bookings = client.fetch_bookings_for_phone("+4791234567")
+
+        assert len(bookings) == 2
+        assert bookings[0].id == "b-1"
+        assert bookings[0].customer_phone == "+4791234567"
+        assert bookings[0].resource_name == "Badstue #1"
+        assert bookings[0].start_time == datetime(2026, 12, 15, 16, 0, tzinfo=UTC)
+        assert bookings[1].id == "b-2"
+
+        req: urllib.request.Request = mock_urlopen.call_args[0][0]
+        assert "bookings?phone=%2B4791234567" in req.full_url
+        assert req.get_method() == "GET"
+
+
 def test_report_inbound_messages_success() -> None:
-    """Test reporting received inbound SMS messages to Snippen."""
+    """Test reporting received inbound SMS messages with booking_id to Snippen."""
     client = SnippenClient(
         api_url="https://vestreholmensameie.no/wp-json/snippen/v1/sms",
         api_token="test-token",
@@ -111,6 +155,8 @@ def test_report_inbound_messages_success() -> None:
             body="JA",
             status=MessageStatus.RECEIVED,
             modem_message_id="modem-101",
+            booking_id="b-101",
+            conversation_id=5,
             created_at=now,
         ),
         Message(
@@ -121,6 +167,8 @@ def test_report_inbound_messages_success() -> None:
             body="NEI",
             status=MessageStatus.RECEIVED,
             modem_message_id="modem-102",
+            booking_id=None,
+            conversation_id=None,
             created_at=now,
         ),
     ]
@@ -140,6 +188,8 @@ def test_report_inbound_messages_success() -> None:
         assert payload["messages"][0]["gateway_id"] == 1
         assert payload["messages"][0]["sender"] == "+4790000001"
         assert payload["messages"][0]["body"] == "JA"
+        assert payload["messages"][0]["booking_id"] == "b-101"
+        assert payload["messages"][0]["conversation_id"] == 5
         assert payload["messages"][0]["modem_message_id"] == "modem-101"
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,304 @@
+"""Tests for Booking Context Resolution and Conversation Management."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from snippen_sms.client import SnippenClient
+from snippen_sms.context import (
+    BookingContextResolver,
+    ResolutionStatus,
+)
+from snippen_sms.models import (
+    Booking,
+    ConversationContext,
+    ConversationState,
+    Message,
+    MessageDirection,
+    MessageStatus,
+)
+from snippen_sms.storage import MessageStorage
+
+
+@pytest.fixture
+def storage() -> MessageStorage:
+    """Create in-memory message storage."""
+    return MessageStorage(db_path=":memory:")
+
+
+@pytest.fixture
+def sample_bookings() -> list[Booking]:
+    """Sample booking dataset."""
+    now = datetime(2026, 12, 15, 16, 0, tzinfo=UTC)
+    later = datetime(2027, 1, 5, 11, 0, tzinfo=UTC)
+    return [
+        Booking(
+            id="book-101",
+            customer_phone="+4791234567",
+            customer_name="Ola Nordmann",
+            start_time=now,
+            resource_name="Badstue",
+            status="confirmed",
+        ),
+        Booking(
+            id="book-202",
+            customer_phone="+4791234567",
+            customer_name="Ola Nordmann",
+            start_time=later,
+            resource_name="Felleslokale",
+            status="confirmed",
+        ),
+    ]
+
+
+def test_parse_selection() -> None:
+    """Verify parsing of selection replies in Norwegian and numeric formats."""
+    # Direct numbers
+    assert BookingContextResolver.parse_selection("1", 3) == 1
+    assert BookingContextResolver.parse_selection(" 2 ", 3) == 2
+    assert BookingContextResolver.parse_selection("3.", 3) == 3
+    assert BookingContextResolver.parse_selection("#2", 3) == 2
+
+    # Prefixes
+    assert BookingContextResolver.parse_selection("nr 1", 3) == 1
+    assert BookingContextResolver.parse_selection("nr. 2", 3) == 2
+    assert BookingContextResolver.parse_selection("nummer 3", 3) == 3
+    assert BookingContextResolver.parse_selection("valg 1", 3) == 1
+    assert BookingContextResolver.parse_selection("booking 2", 3) == 2
+
+    # Ordinals
+    assert BookingContextResolver.parse_selection("første", 3) == 1
+    assert BookingContextResolver.parse_selection("den første", 3) == 1
+    assert BookingContextResolver.parse_selection("andre", 3) == 2
+    assert BookingContextResolver.parse_selection("den andre", 3) == 2
+    assert BookingContextResolver.parse_selection("tredje", 3) == 3
+
+    # Out of bounds & invalid
+    assert BookingContextResolver.parse_selection("4", 3) is None
+    assert BookingContextResolver.parse_selection("0", 3) is None
+    assert BookingContextResolver.parse_selection("hei på deg", 3) is None
+    assert BookingContextResolver.parse_selection("", 3) is None
+
+
+def test_format_selection_prompt(sample_bookings: list[Booking]) -> None:
+    """Verify formatting of multi-booking selection prompt."""
+    prompt = BookingContextResolver.format_selection_prompt(sample_bookings)
+    assert "Du har flere reservasjoner registrert hos oss:" in prompt
+    assert "1. 15.12.2026 kl. 16:00 (Badstue)" in prompt
+    assert "2. 05.01.2027 kl. 11:00 (Felleslokale)" in prompt
+    assert "Vennligst svar med tallet" in prompt
+
+
+def test_resolve_unambiguous_single_booking(
+    storage: MessageStorage,
+    sample_bookings: list[Booking],
+) -> None:
+    """Verify automatic context association when a user has exactly one active booking."""
+    resolver = BookingContextResolver(storage=storage)
+    single_booking = [sample_bookings[0]]
+
+    msg = Message(
+        direction=MessageDirection.INBOUND,
+        sender="+4791234567",
+        recipient="snippen-sms-service",
+        body="Hva er koden til døra?",
+        status=MessageStatus.RECEIVED,
+    )
+    saved_msg = storage.save_message(msg)
+
+    result = resolver.resolve_incoming_message(saved_msg, available_bookings=single_booking)
+
+    assert result.status == ResolutionStatus.RESOLVED
+    assert result.booking_id == "book-101"
+
+    # Verify message is updated in database
+    db_msg = storage.get_message(saved_msg.id)  # type: ignore[arg-type]
+    assert db_msg is not None
+    assert db_msg.booking_id == "book-101"
+
+    # Verify conversation context
+    context = storage.get_conversation_context("+4791234567")
+    assert context is not None
+    assert context.state == ConversationState.RESOLVED
+    assert context.active_booking_id == "book-101"
+
+    # No outbox prompt was queued
+    assert storage.count_outbox() == 0
+
+
+def test_resolve_zero_bookings(storage: MessageStorage) -> None:
+    """Verify clean handling when user has no active bookings."""
+    resolver = BookingContextResolver(storage=storage)
+
+    msg = Message(
+        direction=MessageDirection.INBOUND,
+        sender="+4799999999",
+        recipient="snippen-sms-service",
+        body="Hei, jeg lurer på priser.",
+        status=MessageStatus.RECEIVED,
+    )
+    saved_msg = storage.save_message(msg)
+
+    result = resolver.resolve_incoming_message(saved_msg, available_bookings=[])
+
+    assert result.status == ResolutionStatus.UNRESOLVED
+    assert result.booking_id is None
+
+    db_msg = storage.get_message(saved_msg.id)  # type: ignore[arg-type]
+    assert db_msg is not None
+    assert db_msg.booking_id is None
+
+    context = storage.get_conversation_context("+4799999999")
+    assert context is not None
+    assert context.state == ConversationState.IDLE
+    assert storage.count_outbox() == 0
+
+
+def test_resolve_multiple_bookings_flow(
+    storage: MessageStorage,
+    sample_bookings: list[Booking],
+) -> None:
+    """Verify full interactive selection flow with prompt and numeric reply."""
+    resolver = BookingContextResolver(storage=storage)
+
+    # 1. User sends initial free-text message
+    msg1 = Message(
+        direction=MessageDirection.INBOUND,
+        sender="+4791234567",
+        recipient="snippen-sms-service",
+        body="Ehh, jeg trenger noen bord. Er det mulig å få utvask etterpå?",
+        status=MessageStatus.RECEIVED,
+    )
+    saved_msg1 = storage.save_message(msg1)
+
+    result1 = resolver.resolve_incoming_message(saved_msg1, available_bookings=sample_bookings)
+
+    assert result1.status == ResolutionStatus.PROMPT_SENT
+    assert result1.booking_id is None
+    assert result1.prompt_text is not None
+
+    # Verify context state is awaiting selection
+    context1 = storage.get_conversation_context("+4791234567")
+    assert context1 is not None
+    assert context1.state == ConversationState.AWAITING_SELECTION
+    assert context1.pending_booking_ids == ["book-101", "book-202"]
+    assert context1.pending_message_id == saved_msg1.id
+
+    # Verify prompt SMS was queued to outbox
+    outbox_msgs = storage.get_pending_outbox()
+    assert len(outbox_msgs) == 1
+    assert outbox_msgs[0].recipient == "+4791234567"
+    assert "Du har flere reservasjoner" in outbox_msgs[0].body
+
+    # 2. User replies with "1" to select the first booking
+    msg2 = Message(
+        direction=MessageDirection.INBOUND,
+        sender="+4791234567",
+        recipient="snippen-sms-service",
+        body="1",
+        status=MessageStatus.RECEIVED,
+    )
+    saved_msg2 = storage.save_message(msg2)
+
+    result2 = resolver.resolve_incoming_message(saved_msg2)
+
+    assert result2.status == ResolutionStatus.RESOLVED
+    assert result2.booking_id == "book-101"
+
+    # Both initial message and reply message now have booking_id set
+    db_msg1 = storage.get_message(saved_msg1.id)  # type: ignore[arg-type]
+    db_msg2 = storage.get_message(saved_msg2.id)  # type: ignore[arg-type]
+    assert db_msg1 is not None and db_msg1.booking_id == "book-101"
+    assert db_msg2 is not None and db_msg2.booking_id == "book-101"
+
+    # Context is now resolved
+    context2 = storage.get_conversation_context("+4791234567")
+    assert context2 is not None
+    assert context2.state == ConversationState.RESOLVED
+    assert context2.active_booking_id == "book-101"
+    assert context2.pending_booking_ids == []
+    assert context2.pending_message_id is None
+
+    # 3. Subsequent message from user within TTL automatically inherits active booking
+    msg3 = Message(
+        direction=MessageDirection.INBOUND,
+        sender="+4791234567",
+        recipient="snippen-sms-service",
+        body="Flott, takk!",
+        status=MessageStatus.RECEIVED,
+    )
+    saved_msg3 = storage.save_message(msg3)
+
+    result3 = resolver.resolve_incoming_message(saved_msg3)
+    assert result3.status == ResolutionStatus.RESOLVED
+    assert result3.booking_id == "book-101"
+
+    db_msg3 = storage.get_message(saved_msg3.id)  # type: ignore[arg-type]
+    assert db_msg3 is not None and db_msg3.booking_id == "book-101"
+
+
+def test_session_expiration(
+    storage: MessageStorage,
+    sample_bookings: list[Booking],
+) -> None:
+    """Verify that expired conversation context resets to idle."""
+    resolver = BookingContextResolver(storage=storage, conversation_ttl_seconds=3600.0)
+
+    # Setup context with old timestamp (3 hours ago)
+    old_time = datetime.now(UTC) - timedelta(hours=3)
+    context = ConversationContext(
+        phone_number="+4791234567",
+        active_booking_id="book-101",
+        state=ConversationState.RESOLVED,
+        last_activity_at=old_time,
+    )
+    storage.save_conversation_context(context)
+
+    # Incoming message after TTL should refresh context with available bookings
+    msg = Message(
+        direction=MessageDirection.INBOUND,
+        sender="+4791234567",
+        recipient="snippen-sms-service",
+        body="Ny melding etter lang tid",
+        status=MessageStatus.RECEIVED,
+    )
+    saved_msg = storage.save_message(msg)
+
+    # Since user now has 2 bookings, it should prompt again
+    result = resolver.resolve_incoming_message(saved_msg, available_bookings=sample_bookings)
+    assert result.status == ResolutionStatus.PROMPT_SENT
+
+
+def test_resolver_with_snippen_client(storage: MessageStorage) -> None:
+    """Verify integration between resolver and SnippenClient."""
+    mock_client = MagicMock(spec=SnippenClient)
+    now = datetime(2026, 12, 15, 16, 0, tzinfo=UTC)
+    mock_client.fetch_bookings_for_phone.return_value = [
+        Booking(
+            id="book-999",
+            customer_phone="+4791234567",
+            customer_name="Test Bruker",
+            start_time=now,
+            resource_name="Badstue #2",
+        )
+    ]
+
+    resolver = BookingContextResolver(storage=storage, client=mock_client)
+
+    msg = Message(
+        direction=MessageDirection.INBOUND,
+        sender="+4791234567",
+        recipient="snippen-sms-service",
+        body="Trenger vi nøkkel?",
+        status=MessageStatus.RECEIVED,
+    )
+    saved_msg = storage.save_message(msg)
+
+    result = resolver.resolve_incoming_message(saved_msg)
+
+    assert result.status == ResolutionStatus.RESOLVED
+    assert result.booking_id == "book-999"
+    mock_client.fetch_bookings_for_phone.assert_called_once_with("+4791234567")

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from snippen_sms import __version__
+from snippen_sms.client import SnippenClient
 from snippen_sms.config import GatewayConfig
 from snippen_sms.gateway import GatewayService
 from snippen_sms.models import MessageDirection, MessageStatus
@@ -706,3 +707,48 @@ def test_gateway_sync_with_snippen():
     assert len(pending) == 1
     assert pending[0].external_id == "wp-1"
     assert pending[0].body == "SMS from WP"
+
+
+def test_gateway_incoming_message_with_booking_resolver():
+    """Test that incoming messages polled via gateway automatically resolve booking context."""
+    from datetime import UTC, datetime
+    from unittest.mock import MagicMock
+
+    from snippen_sms.models import Booking
+
+    async def _test():
+        config = GatewayConfig(
+            database_path=":memory:",
+            booking_resolution_enabled=True,
+        )
+        provider = InMemorySmsProvider()
+        mock_client = MagicMock(spec=SnippenClient)
+        now = datetime(2026, 12, 15, 16, 0, tzinfo=UTC)
+        mock_client.fetch_bookings_for_phone.return_value = [
+            Booking(
+                id="book-abc",
+                customer_phone="+4790011223",
+                start_time=now,
+                resource_name="Badstue",
+            )
+        ]
+
+        service = GatewayService(config=config, provider=provider, client=mock_client)
+        await service.start()
+
+        # Simulate incoming SMS from guest
+        provider.simulate_incoming(sender="+4790011223", body="Hva er koden?")
+
+        # Poll incoming messages
+        messages = await service.poll_incoming_messages()
+        assert len(messages) == 1
+        assert messages[0].booking_id == "book-abc"
+
+        # Check stored in database
+        db_msg = service.storage.get_message(messages[0].id)
+        assert db_msg is not None
+        assert db_msg.booking_id == "book-abc"
+
+        await service.stop()
+
+    asyncio.run(_test())

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -533,3 +533,83 @@ def test_storage_external_id_and_outbox_reporting(memory_storage: MessageStorage
 
     # Should no longer be in unreported list
     assert len(memory_storage.get_unreported_outbox_statuses()) == 0
+
+
+def test_storage_booking_and_conversation_context(memory_storage: MessageStorage) -> None:
+    """Test saving and retrieving messages with booking_id and conversation_id."""
+    msg = memory_storage.save_message(
+        Message(
+            direction=MessageDirection.INBOUND,
+            sender="+4791234567",
+            recipient="snippen-sms-service",
+            body="Hei, booking spm",
+            booking_id="book-555",
+            conversation_id=12,
+        )
+    )
+    assert msg.id is not None
+    assert msg.booking_id == "book-555"
+    assert msg.conversation_id == 12
+
+    fetched = memory_storage.get_message(msg.id)
+    assert fetched is not None
+    assert fetched.booking_id == "book-555"
+    assert fetched.conversation_id == 12
+
+    # Query by booking ID
+    by_booking = memory_storage.list_messages_by_booking("book-555")
+    assert len(by_booking) == 1
+    assert by_booking[0].id == msg.id
+
+    # Query by phone
+    by_phone = memory_storage.list_messages_by_phone("+4791234567")
+    assert len(by_phone) == 1
+    assert by_phone[0].id == msg.id
+
+    # Update booking context
+    memory_storage.update_message_booking_context(msg.id, booking_id="book-666", conversation_id=13)
+    refreshed = memory_storage.get_message(msg.id)
+    assert refreshed is not None
+    assert refreshed.booking_id == "book-666"
+    assert refreshed.conversation_id == 13
+
+
+def test_storage_conversation_context_crud(memory_storage: MessageStorage) -> None:
+    """Test ConversationContext CRUD operations."""
+    from snippen_sms.models import ConversationContext, ConversationState
+
+    assert memory_storage.get_conversation_context("+4791112233") is None
+
+    ctx = ConversationContext(
+        phone_number="+4791112233",
+        active_booking_id="book-100",
+        pending_booking_ids=["book-100", "book-200"],
+        pending_message_id=42,
+        state=ConversationState.AWAITING_SELECTION,
+    )
+    saved = memory_storage.save_conversation_context(ctx)
+    assert saved.id is not None
+    assert saved.phone_number == "+4791112233"
+    assert saved.state == ConversationState.AWAITING_SELECTION
+    assert saved.pending_booking_ids == ["book-100", "book-200"]
+    assert saved.pending_message_id == 42
+
+    # Retrieve
+    retrieved = memory_storage.get_conversation_context("+4791112233")
+    assert retrieved is not None
+    assert retrieved.id == saved.id
+    assert retrieved.pending_booking_ids == ["book-100", "book-200"]
+
+    # Update
+    retrieved.state = ConversationState.RESOLVED
+    retrieved.active_booking_id = "book-200"
+    retrieved.pending_booking_ids = []
+    retrieved.pending_message_id = None
+    updated = memory_storage.save_conversation_context(retrieved)
+    assert updated.state == ConversationState.RESOLVED
+    assert updated.active_booking_id == "book-200"
+    assert updated.pending_booking_ids == []
+
+    # Delete
+    assert memory_storage.delete_conversation_context("+4791112233") is True
+    assert memory_storage.get_conversation_context("+4791112233") is None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 from snippen_sms.client import SnippenClient, SnippenNetworkError
@@ -183,3 +184,45 @@ def test_sync_all_e2e() -> None:
     assert res["outbox_enqueued"] == 1
     assert res["statuses_reported"] == 0
     assert res["error"] is None
+
+
+def test_sync_inbox_with_booking_resolver() -> None:
+    """Test that sync_inbox resolves booking context before reporting to Snippen."""
+    from snippen_sms.context import BookingContextResolver
+    from snippen_sms.models import Booking
+
+    storage = MessageStorage(":memory:")
+    now = datetime(2026, 12, 15, 16, 0, tzinfo=UTC)
+    msg = storage.save_message(
+        Message(
+            direction=MessageDirection.INBOUND,
+            sender="+4791234567",
+            recipient="snippen-sms-service",
+            body="Hei, trenger info",
+            status=MessageStatus.RECEIVED,
+        )
+    )
+    assert msg.id is not None
+
+    mock_client = MagicMock(spec=SnippenClient)
+    mock_client.fetch_bookings_for_phone.return_value = [
+        Booking(
+            id="book-777",
+            customer_phone="+4791234567",
+            start_time=now,
+            resource_name="Badstue",
+        )
+    ]
+    mock_client.report_inbound_messages.return_value = [msg.id]
+
+    resolver = BookingContextResolver(storage=storage, client=mock_client)
+    sync = SyncService(storage=storage, client=mock_client, resolver=resolver)
+
+    acked = sync.sync_inbox()
+    assert acked == [msg.id]
+
+    # Verify message was updated with booking_id
+    updated_msg = storage.get_message(msg.id)
+    assert updated_msg is not None
+    assert updated_msg.booking_id == "book-777"
+    assert updated_msg.status == MessageStatus.PROCESSED


### PR DESCRIPTION
Closes #28

### Summary of Changes
- Implemented `BookingContextResolver` in `src/snippen_sms/context.py` to associate incoming SMS conversations with Snippen bookings.
- Unambiguous single booking: automatically associates the incoming message with the customer's active booking.
- Multiple active bookings: enqueues a friendly, numbered clarification prompt in Norwegian with human dates/times and resource names.
- Natural language & numeric reply parsing: resolves user selection (`1`, `2`, `Nr 1`, `første`, etc.) without rigid SMS commands.
- Session TTL continuation: preserves active booking context for subsequent messages within a configurable window (default 2 hours).
- Database migration `0004_messages_booking_context.sql` adding `booking_id` and `conversation_id` columns to `messages` and creating `conversation_contexts` tracking table.
- Extended `SnippenClient` with `fetch_bookings_for_phone()` and reporting `booking_id` in `POST /wp-json/snippen/v1/sms/inbox`.
- Integrated resolver into `GatewayService.poll_incoming_messages()` and `SyncService.sync_inbox()`.
- Added comprehensive unit and integration test suite (`tests/test_context.py` and updated tests).
- Updated architecture diagrams and WordPress REST API specification (`docs/snippen_booking_api_spec.md`).