### PR TITLE
(#42) Implementer HTTP-provider og E2E-testing mot fake SMS-provider

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,17 +13,18 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "charliermarsh.ruff",
-        "google.google-antigravity",
         "mermaidchart.vscode-mermaid-chart"
+      ],
+      "recommendations": [
+        "google.google-antigravity"
       ]
     }
   },
   "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.gemini;python3 -m venv /home/vscode/.venv && /home/vscode/.venv/bin/pip install -e \".[dev]\"",
   "remoteUser": "vscode",
-
   "mounts": [
-        "source=snippen-sms-service-gemini,target=/home/vscode/.gemini/config,type=volume",
-        "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind,consistency=cached"
+    "source=snippen-sms-service-gemini,target=/home/vscode/.gemini/config,type=volume",
+    "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind,consistency=cached"
   ],
   "workspaceFolder": "/workspaces/snippen-sms-service",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/snippen-sms-service,type=bind,consistency=cached"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-09-01
+
+### Added
+- Implemented `HttpSmsProvider` connecting `snippen-sms-service` to remote HTTP SMS providers and the `snippen-testing` fake SMS provider (`#42`).
+- Registered `http`, `fake`, and `snippen-testing` aliases in `PROVIDER_REGISTRY` (`#42`).
+- Added `SNIPPEN_SMS_PROVIDER_URL` and `SNIPPEN_SMS_PROVIDER_TIMEOUT` environment variable configurations and `--provider-url` CLI parameter (`#42`).
+- Added `snippen-sms send` CLI command to directly send SMS messages via configured providers (`#42`).
+- Added comprehensive unit tests in `tests/test_http_provider.py` and end-to-end integration tests in `tests/test_fake_provider_e2e.py` covering outbound delivery, inbound polling/deduplication, and failure handling (`#42`).
+
+### Changed
+- Updated `GatewayService` to pass provider configuration parameters (`provider_url`, `timeout_seconds`) when instantiating providers (`#42`).
+- Extended documentation in `README.md` and `DEV_README.md` with step-by-step testing instructions using CLI and HTTP calls (`#42`).
+
 ## [0.14.0] - 2026-08-30
 
 ### Added

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -33,6 +33,7 @@ snippen-sms-service/
 │       ├── providers/        # SMS provider abstraction layer
 │       │   ├── __init__.py   # Provider exports & factory registry
 │       │   ├── base.py       # SmsProvider ABC, SendResult, IncomingMessage
+│       │   ├── http.py       # HttpSmsProvider for HTTP SMS gateways & fake-provider
 │       │   ├── memory.py     # InMemorySmsProvider for testing & simulation
 │       │   └── mock.py       # MockSmsProvider for mock messaging & auto-replies
 │       ├── storage.py        # SQLite persistent storage repository
@@ -43,8 +44,10 @@ snippen-sms-service/
 │   ├── test_build_release.py # Release build & checksum calculation tests
 │   ├── test_client.py        # SnippenClient HTTP client tests
 │   ├── test_context.py       # Booking context resolution & dialogue session tests
+│   ├── test_fake_provider_e2e.py # End-to-end integration tests with fake SMS provider
 │   ├── test_format.py        # Formatter tests
 │   ├── test_gateway.py       # GatewayService lifecycle & provider integration tests
+│   ├── test_http_provider.py # HttpSmsProvider unit tests
 │   ├── test_main.py          # Unit tests
 │   ├── test_migrations.py    # Database migration unit & integration tests
 │   ├── test_mock_provider.py # Mock SMS provider and factory tests
@@ -89,6 +92,49 @@ For high-level system architecture, communication flows, and boundaries, see [do
    # Validate PR version bump and changelog
    python scripts/validate_pr.py --base origin/main
    ```
+
+## Manual & End-to-End Testing with Fake SMS Provider
+
+To test the complete SMS messaging cycle (outbound dispatch, inbound message injection, polling, and deduplication) between `snippen-sms-service` and the fake SMS provider in `snippen-testing`:
+
+### 1. Launch the Fake SMS Provider
+From the `snippen-testing` workspace:
+```bash
+cd /workspaces/snippen-testing
+npm start
+# Listens on http://127.0.0.1:3000
+```
+
+### 2. Start the SMS Gateway Service
+From the `snippen-sms-service` workspace:
+```bash
+cd /workspaces/snippen-sms-service
+snippen-sms run --provider fake --provider-url http://127.0.0.1:3000 --log-level DEBUG
+```
+
+### 3. Send Outbound SMS (CLI & Inspection)
+Send an outbound SMS message:
+```bash
+snippen-sms send --to "+4799887766" --message "Din adgangskode er 4821" --provider fake --provider-url http://127.0.0.1:3000
+```
+Inspect outbound messages stored in the fake provider:
+```bash
+curl "http://127.0.0.1:3000/messages?direction=outbound"
+```
+
+### 4. Inject Inbound SMS & Verify Ingestion
+Inject a simulated inbound SMS reply:
+```bash
+curl -X POST "http://127.0.0.1:3000/messages/inbound" \
+  -H "Content-Type: application/json" \
+  -d '{"from": "+4799887766", "text": "Hei, adgangskoden virket fint!"}'
+```
+Observe the `snippen-sms-service` logs as it polls the fake provider (`GET /messages?direction=inbound`), ingests the message into the local SQLite database, and resolves any active booking context.
+
+Clear provider state when needed:
+```bash
+curl -X DELETE "http://127.0.0.1:3000/messages"
+```
 
 ## CI/CD Workflows
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The gateway service can be configured via CLI flags or environment variables:
 | Log Level | `SNIPPEN_SMS_LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | Poll Interval | `SNIPPEN_SMS_POLL_INTERVAL` | `2.0` | Polling loop tick interval in seconds |
 | Database Path | `SNIPPEN_SMS_DATABASE_PATH` | `data/sms_gateway.db` | Path to SQLite database file (or `:memory:`) |
-| Provider | `SNIPPEN_SMS_PROVIDER` | `mock` | SMS provider backend (`mock`, `memory`) |
+| Provider | `SNIPPEN_SMS_PROVIDER` | `mock` | SMS provider backend (`mock`, `memory`, `fake`, `http`) |
+| Provider URL | `SNIPPEN_SMS_PROVIDER_URL` | *(None)* | Remote SMS Provider endpoint URL (e.g. `http://127.0.0.1:3000`) |
+| Provider Timeout | `SNIPPEN_SMS_PROVIDER_TIMEOUT` | `10.0` | HTTP request timeout for SMS provider in seconds |
 | Snippen API URL | `SNIPPEN_SMS_API_URL` | *(None)* | Snippen WordPress REST API base URL |
 | Snippen API Token | `SNIPPEN_SMS_API_TOKEN` | *(None)* | Shared Bearer/API token for Snippen authentication |
 | Sync Interval | `SNIPPEN_SMS_SYNC_INTERVAL` | `5.0` | Synchronization interval in seconds |
@@ -71,6 +73,76 @@ python -m snippen_sms.main
 # Or run with custom provider, poll interval, log level, and database path
 python -m snippen_sms.main --provider mock --poll-interval 1.0 --log-level DEBUG
 ```
+
+Send a test SMS directly via CLI:
+
+```bash
+# Send an SMS directly using configured provider
+snippen-sms send --to "+4799887766" --message "Hei! Din kode er 1234." --provider mock
+```
+
+---
+
+## End-to-End Testing with Fake SMS Provider
+
+You can test both outbound dispatching and inbound message polling end-to-end locally using the **Fake SMS Provider** in `snippen-testing`:
+
+### 1. Start the Fake SMS Provider
+
+In a terminal in `/workspaces/snippen-testing`:
+
+```bash
+npm start
+# Server starts on http://127.0.0.1:3000
+```
+
+### 2. Start Snippen SMS Service against Fake Provider
+
+In a terminal in `/workspaces/snippen-sms-service`:
+
+```bash
+snippen-sms run --provider fake --provider-url http://127.0.0.1:3000 --log-level DEBUG
+```
+
+### 3. Send Outbound SMS (CLI)
+
+In another terminal, send an SMS:
+
+```bash
+snippen-sms send --to "+4799887766" --message "Adgangskode: 4821" --provider fake --provider-url http://127.0.0.1:3000
+```
+
+Verify that the message was received by the fake provider via HTTP:
+
+```bash
+curl "http://127.0.0.1:3000/messages?direction=outbound"
+```
+
+### 4. Inject Inbound SMS & Poll (HTTP + CLI)
+
+> [!NOTE]
+> The `POST /messages/inbound` endpoint on `snippen-testing` is a **test injection endpoint** used to simulate an incoming message from a guest. It is **not** a webhook exposed by the SMS service. `snippen-sms-service` polls the provider (`GET /messages?direction=inbound`) and deduplicates incoming messages.
+
+Simulate a guest replying with an SMS:
+
+```bash
+curl -X POST "http://127.0.0.1:3000/messages/inbound" \
+  -H "Content-Type: application/json" \
+  -d '{"from": "+4799887766", "text": "Hei, vi har låst oss ute."}'
+```
+
+Watch the running `snippen-sms-service` log. On the next polling cycle, the service will:
+1. Fetch the inbound SMS from the fake provider.
+2. Ingest and persist the message into SQLite with status `received`.
+3. Deduplicate automatically on subsequent poll ticks so messages are never processed twice.
+
+To clear all messages in the fake provider between tests:
+
+```bash
+curl -X DELETE "http://127.0.0.1:3000/messages"
+```
+
+---
 
 Check for software updates and upgrade:
 
@@ -98,7 +170,6 @@ Trigger manual Snippen API synchronization:
 # Execute a one-time synchronization cycle with Snippen
 snippen-sms sync --api-url https://vestreholmensameie.no/wp-json/snippen/v1/sms --api-token <token>
 ```
-
 
 Run the test suite, code linter, and formatting tool in the development environment:
 

--- a/docs/sms-service-test-queries/.gitignore
+++ b/docs/sms-service-test-queries/.gitignore
@@ -1,0 +1,9 @@
+# Secrets
+.env*
+
+# Dependencies
+node_modules
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/docs/sms-service-test-queries/opencollection.yml
+++ b/docs/sms-service-test-queries/opencollection.yml
@@ -1,0 +1,10 @@
+opencollection: 1.0.0
+
+info:
+  name: sms-service-test-queries
+bundled: false
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git

--- a/src/snippen_sms/__init__.py
+++ b/src/snippen_sms/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 from snippen_sms.client import (
     SnippenApiError,
@@ -28,6 +28,7 @@ from snippen_sms.models import (
     MessageStatus,
 )
 from snippen_sms.providers import (
+    HttpSmsProvider,
     IncomingMessage,
     InMemorySmsProvider,
     MockSMSProvider,
@@ -55,6 +56,7 @@ __all__ = [
     "ConversationState",
     "GatewayConfig",
     "GatewayService",
+    "HttpSmsProvider",
     "InMemorySmsProvider",
     "IncomingMessage",
     "Message",

--- a/src/snippen_sms/config.py
+++ b/src/snippen_sms/config.py
@@ -15,6 +15,8 @@ class GatewayConfig:
     poll_interval_seconds: float = 2.0
     database_path: str = "data/sms_gateway.db"
     provider: str = "mock"
+    provider_url: str | None = None
+    provider_timeout_seconds: float = 10.0
     github_repo: str = "jonasfh/snippen-sms-service"
     check_updates_on_startup: bool = True
     auto_update_check: bool = True
@@ -49,6 +51,8 @@ class GatewayConfig:
             poll_interval_seconds=float(os.getenv("SNIPPEN_SMS_POLL_INTERVAL", "2.0")),
             database_path=os.getenv("SNIPPEN_SMS_DATABASE_PATH", "data/sms_gateway.db"),
             provider=os.getenv("SNIPPEN_SMS_PROVIDER", "mock"),
+            provider_url=os.getenv("SNIPPEN_SMS_PROVIDER_URL"),
+            provider_timeout_seconds=float(os.getenv("SNIPPEN_SMS_PROVIDER_TIMEOUT", "10.0")),
             github_repo=os.getenv("SNIPPEN_SMS_GITHUB_REPO", "jonasfh/snippen-sms-service"),
             check_updates_on_startup=check_startup_env in ("true", "1", "yes"),
             auto_update_check=auto_check_env in ("true", "1", "yes"),

--- a/src/snippen_sms/gateway.py
+++ b/src/snippen_sms/gateway.py
@@ -35,7 +35,15 @@ class GatewayService:
     ) -> None:
         self.config = config or GatewayConfig()
         self.storage = storage or MessageStorage(self.config.database_path)
-        self.provider = provider or get_provider(self.config.provider)
+        if provider is not None:
+            self.provider = provider
+        else:
+            provider_kwargs: dict[str, Any] = {}
+            if self.config.provider_url:
+                provider_kwargs["base_url"] = self.config.provider_url
+            if self.config.provider_timeout_seconds:
+                provider_kwargs["timeout_seconds"] = self.config.provider_timeout_seconds
+            self.provider = get_provider(self.config.provider, **provider_kwargs)
         self.updater = updater or SoftwareUpdater(
             github_repo=self.config.github_repo,
             github_token=self.config.github_token,

--- a/src/snippen_sms/main.py
+++ b/src/snippen_sms/main.py
@@ -182,6 +182,39 @@ def handle_sync(
     return 0
 
 
+def handle_send(
+    recipient: str,
+    body: str,
+    provider_name: str | None = None,
+    provider_url: str | None = None,
+    database_path: str = "data/sms_gateway.db",
+) -> int:
+    """Send an SMS directly using the configured provider."""
+    env_config = GatewayConfig.from_env()
+    config = GatewayConfig(
+        service_name=env_config.service_name,
+        database_path=database_path,
+        provider=provider_name or env_config.provider,
+        provider_url=provider_url or env_config.provider_url,
+        sync_enabled=False,
+    )
+    service = GatewayService(config=config)
+    print(f"Sending SMS to {recipient} via provider '{config.provider}'...")
+    try:
+        msg = asyncio.run(service.send_sms(recipient=recipient, body=body))
+        if msg.status.value == "sent":
+            print(f"✅ SMS sent successfully! (ID: {msg.id}, Provider ID: {msg.modem_message_id})")
+            return 0
+        else:
+            print(
+                f"❌ SMS delivery failed (status: {msg.status.value}). Error: {msg.error_message}"
+            )
+            return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"❌ Exception while sending SMS: {exc}")
+        return 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build command line argument parser."""
     parser = argparse.ArgumentParser(
@@ -218,6 +251,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         help="SMS provider implementation to use (default: mock)",
+    )
+    parser.add_argument(
+        "--provider-url",
+        type=str,
+        default=None,
+        help="SMS HTTP provider base URL (default: SNIPPEN_SMS_PROVIDER_URL)",
     )
     parser.add_argument(
         "--api-url",
@@ -273,6 +312,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="SMS provider implementation to use (default: mock)",
     )
     run_parser.add_argument(
+        "--provider-url",
+        type=str,
+        default=None,
+        help="SMS HTTP provider base URL",
+    )
+    run_parser.add_argument(
         "--api-url",
         type=str,
         default=None,
@@ -294,6 +339,44 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-sync",
         action="store_true",
         help="Disable automatic synchronization with Snippen",
+    )
+
+    # Send subcommand
+    send_parser = subparsers.add_parser(
+        "send",
+        help="Directly send an SMS message via configured provider",
+    )
+    send_parser.add_argument(
+        "--to",
+        type=str,
+        required=True,
+        help="Destination phone number",
+    )
+    send_parser.add_argument(
+        "--message",
+        "--text",
+        dest="message",
+        type=str,
+        required=True,
+        help="Text content of the SMS message",
+    )
+    send_parser.add_argument(
+        "--provider",
+        type=str,
+        default=None,
+        help="SMS provider implementation to use",
+    )
+    send_parser.add_argument(
+        "--provider-url",
+        type=str,
+        default=None,
+        help="SMS provider base URL",
+    )
+    send_parser.add_argument(
+        "--database-path",
+        type=str,
+        default="data/sms_gateway.db",
+        help="Database file path (default: data/sms_gateway.db)",
     )
 
     # Sync subcommand
@@ -392,7 +475,17 @@ def main_cli() -> None:
 
     env_config = GatewayConfig.from_env()
 
-    if args.command == "sync":
+    if args.command == "send":
+        sys.exit(
+            handle_send(
+                recipient=args.to,
+                body=args.message,
+                provider_name=getattr(args, "provider", None),
+                provider_url=getattr(args, "provider_url", None),
+                database_path=getattr(args, "database_path", env_config.database_path),
+            )
+        )
+    elif args.command == "sync":
         api_url = getattr(args, "api_url", None) or env_config.snippen_api_url
         api_token = getattr(args, "api_token", None) or env_config.snippen_api_token
         db_path = getattr(args, "database_path", env_config.database_path)
@@ -420,6 +513,7 @@ def main_cli() -> None:
         db_path = getattr(args, "database_path", "data/sms_gateway.db")
         poll_interval = getattr(args, "poll_interval", 2.0)
         provider_arg = getattr(args, "provider", None)
+        provider_url_arg = getattr(args, "provider_url", None)
         api_url = getattr(args, "api_url", None) or env_config.snippen_api_url
         api_token = getattr(args, "api_token", None) or env_config.snippen_api_token
         sync_interval = getattr(args, "sync_interval", None)
@@ -434,6 +528,7 @@ def main_cli() -> None:
             poll_interval_seconds=poll_interval,
             database_path=db_path,
             provider=provider_arg or env_config.provider,
+            provider_url=provider_url_arg or env_config.provider_url,
             github_repo=env_config.github_repo,
             check_updates_on_startup=env_config.check_updates_on_startup,
             auto_update_check=env_config.auto_update_check,

--- a/src/snippen_sms/providers/__init__.py
+++ b/src/snippen_sms/providers/__init__.py
@@ -3,24 +3,30 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 from snippen_sms.providers.base import IncomingMessage, SendResult, SmsProvider
+from snippen_sms.providers.http import HttpSmsProvider
 from snippen_sms.providers.memory import InMemorySmsProvider
 from snippen_sms.providers.mock import AutoReplyRule, MockSMSProvider, MockSmsProvider, SentRecord
 
-PROVIDER_REGISTRY: dict[str, type[SmsProvider] | Callable[[], SmsProvider]] = {
+PROVIDER_REGISTRY: dict[str, type[SmsProvider] | Callable[..., SmsProvider]] = {
     "mock": MockSmsProvider,
     "memory": InMemorySmsProvider,
     "in_memory": InMemorySmsProvider,
     "inmemory": InMemorySmsProvider,
+    "http": HttpSmsProvider,
+    "fake": HttpSmsProvider,
+    "snippen-testing": HttpSmsProvider,
 }
 
 
-def get_provider(name: str = "mock") -> SmsProvider:
+def get_provider(name: str = "mock", **kwargs: Any) -> SmsProvider:
     """Retrieve and instantiate an SMS provider by name.
 
     Args:
-        name: Name of the provider ('mock', 'memory', etc.).
+        name: Name of the provider ('mock', 'memory', 'http', 'fake', etc.).
+        **kwargs: Optional configuration arguments passed to the provider constructor.
 
     Returns:
         An instantiated SmsProvider instance.
@@ -33,24 +39,32 @@ def get_provider(name: str = "mock") -> SmsProvider:
     if provider_cls is None:
         valid_providers = ", ".join(sorted(PROVIDER_REGISTRY.keys()))
         raise ValueError(f"Unknown SMS provider '{name}'. Valid providers are: {valid_providers}")
+
+    # Pass kwargs if provided and accepted, otherwise instantiate without arguments
+    if kwargs:
+        try:
+            return provider_cls(**kwargs)
+        except TypeError:
+            pass
     return provider_cls()
 
 
 def register_provider(
     name: str,
-    provider_cls: type[SmsProvider] | Callable[[], SmsProvider],
+    provider_cls: type[SmsProvider] | Callable[..., SmsProvider],
 ) -> None:
     """Register a custom SMS provider class or factory in the provider registry.
 
     Args:
         name: Unique identifier for the provider.
-        provider_cls: SmsProvider subclass or zero-argument callable factory.
+        provider_cls: SmsProvider subclass or factory function.
     """
     PROVIDER_REGISTRY[name.strip().lower()] = provider_cls
 
 
 __all__ = [
     "AutoReplyRule",
+    "HttpSmsProvider",
     "InMemorySmsProvider",
     "IncomingMessage",
     "MockSMSProvider",

--- a/src/snippen_sms/providers/http.py
+++ b/src/snippen_sms/providers/http.py
@@ -1,0 +1,234 @@
+"""HTTP SMS provider for external and simulated SMS gateways (e.g. snippen-testing)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from typing import Any
+
+from snippen_sms import __version__
+from snippen_sms.providers.base import IncomingMessage, SendResult, SmsProvider
+
+logger = logging.getLogger("snippen_sms.providers.http")
+
+
+class HttpSmsProvider(SmsProvider):
+    """SMS provider communicating via HTTP REST APIs (compatible with snippen-testing fake SMS provider)."""
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:3000",
+        timeout_seconds: float = 10.0,
+        sender_id: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        self.base_url = (base_url or "http://127.0.0.1:3000").rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.sender_id = sender_id
+        self.api_key = api_key
+
+    def _sync_request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> tuple[int, Any]:
+        """Execute synchronous HTTP request with error translation."""
+        subpath = path.lstrip("/")
+        url = f"{self.base_url}/{subpath}"
+        if query_params:
+            encoded_params = urllib.parse.urlencode(query_params)
+            url = f"{url}?{encoded_params}"
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": f"snippen-sms-service/{__version__}",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+            headers["X-API-Key"] = self.api_key
+
+        data_bytes: bytes | None = None
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+            data_bytes = json.dumps(payload).encode("utf-8")
+
+        req = urllib.request.Request(
+            url=url,
+            data=data_bytes,
+            headers=headers,
+            method=method.upper(),
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_seconds) as resp:
+                status_code = resp.status
+                raw_body = resp.read().decode("utf-8")
+                if not raw_body.strip():
+                    return status_code, {}
+                try:
+                    return status_code, json.loads(raw_body)
+                except json.JSONDecodeError:
+                    return status_code, {"raw": raw_body}
+
+        except urllib.error.HTTPError as exc:
+            error_body = ""
+            try:
+                error_body = exc.read().decode("utf-8")
+            except (OSError, UnicodeDecodeError):
+                pass
+            raise RuntimeError(
+                f"HTTP {exc.code} from {method.upper()} {url}: {error_body or exc.reason}"
+            ) from exc
+
+        except urllib.error.URLError as exc:
+            raise ConnectionError(f"Connection failed to {url}: {exc.reason}") from exc
+
+        except TimeoutError as exc:
+            raise TimeoutError(f"Request to {url} timed out after {self.timeout_seconds}s") from exc
+
+    async def _async_request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> tuple[int, Any]:
+        """Execute request non-blockingly using thread pool."""
+        return await asyncio.to_thread(self._sync_request, method, path, payload, query_params)
+
+    async def open(self) -> None:
+        """Initialize provider interface."""
+        logger.debug("Initialized HttpSmsProvider targeting %s", self.base_url)
+
+    async def close(self) -> None:
+        """Release provider resources."""
+        logger.debug("Closed HttpSmsProvider targeting %s", self.base_url)
+
+    async def send_sms(self, recipient: str, body: str) -> SendResult:
+        """Send an SMS message via HTTP to the remote provider gateway.
+
+        Args:
+            recipient: The destination phone number.
+            body: The text message content.
+
+        Returns:
+            SendResult indicating status and message reference or error details.
+        """
+        payload: dict[str, Any] = {
+            "to": recipient.strip(),
+            "text": body.strip(),
+        }
+        if self.sender_id:
+            payload["from"] = self.sender_id.strip()
+
+        try:
+            status_code, response_data = await self._async_request(
+                method="POST",
+                path="messages/outbound",
+                payload=payload,
+            )
+
+            if status_code in (200, 201):
+                msg_id = None
+                if isinstance(response_data, dict):
+                    msg_id = (
+                        response_data.get("id")
+                        or response_data.get("message_id")
+                        or response_data.get("messageId")
+                    )
+                provider_msg_id = str(msg_id) if msg_id is not None else None
+                logger.info(
+                    "Successfully transmitted SMS to %s via %s (Provider ID: %s)",
+                    recipient,
+                    self.base_url,
+                    provider_msg_id,
+                )
+                return SendResult(success=True, message_id=provider_msg_id)
+
+            err_msg = f"Unexpected response status {status_code} from provider"
+            logger.warning("Failed to send SMS to %s: %s", recipient, err_msg)
+            return SendResult(success=False, error_message=err_msg)
+
+        except Exception as exc:  # noqa: BLE001
+            err_msg = str(exc)
+            logger.warning("Error sending SMS to %s via %s: %s", recipient, self.base_url, err_msg)
+            return SendResult(success=False, error_message=err_msg)
+
+    async def receive_sms(self) -> list[IncomingMessage]:
+        """Fetch and drain pending incoming SMS messages from the HTTP provider.
+
+        Returns:
+            List of IncomingMessage instances retrieved from provider.
+        """
+        try:
+            status_code, response_data = await self._async_request(
+                method="GET",
+                path="messages",
+                query_params={"direction": "inbound"},
+            )
+
+            if status_code != 200:
+                logger.warning(
+                    "Provider returned HTTP %s when polling inbound messages", status_code
+                )
+                return []
+
+            raw_messages: list[dict[str, Any]] = []
+            if isinstance(response_data, list):
+                raw_messages = response_data
+            elif isinstance(response_data, dict):
+                items = (
+                    response_data.get("messages")
+                    or response_data.get("items")
+                    or response_data.get("data")
+                )
+                if isinstance(items, list):
+                    raw_messages = items
+
+            inbound_list: list[IncomingMessage] = []
+            for item in raw_messages:
+                sender = str(item.get("from") or item.get("sender") or "").strip()
+                text = str(
+                    item.get("text") or item.get("message") or item.get("body") or ""
+                ).strip()
+
+                if not sender or not text:
+                    continue
+
+                provider_msg_id = item.get("id") or item.get("message_id")
+                str_msg_id = str(provider_msg_id) if provider_msg_id is not None else None
+
+                created_raw = (
+                    item.get("createdAt") or item.get("created_at") or item.get("timestamp")
+                )
+                received_dt = datetime.now(UTC)
+                if created_raw:
+                    try:
+                        parsed_dt = datetime.fromisoformat(str(created_raw))
+                        if parsed_dt.tzinfo is None:
+                            parsed_dt = parsed_dt.replace(tzinfo=UTC)
+                        received_dt = parsed_dt
+                    except (ValueError, TypeError) as parse_exc:
+                        logger.debug("Could not parse timestamp %s: %s", created_raw, parse_exc)
+
+                inbound_list.append(
+                    IncomingMessage(
+                        sender=sender,
+                        body=text,
+                        received_at=received_dt,
+                        provider_message_id=str_msg_id,
+                    )
+                )
+
+            return inbound_list
+
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Error polling incoming SMS messages from %s: %s", self.base_url, exc)
+            return []

--- a/tests/test_fake_provider_e2e.py
+++ b/tests/test_fake_provider_e2e.py
@@ -1,0 +1,293 @@
+"""End-to-end integration tests connecting GatewayService to a simulated Fake SMS Provider."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import ClassVar
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from snippen_sms.config import GatewayConfig
+from snippen_sms.gateway import GatewayService
+from snippen_sms.models import MessageDirection, MessageStatus
+from snippen_sms.storage import MessageStorage
+
+
+class FakeSmsProviderSimulator(BaseHTTPRequestHandler):
+    """Accurate in-memory HTTP server mimicking the fake SMS provider from snippen-testing."""
+
+    messages: ClassVar[list[dict]] = []
+    fail_next_outbound: ClassVar[bool] = False
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.messages = []
+        cls.fail_next_outbound = False
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        content_len = int(self.headers.get("Content-Length", 0))
+        post_body = self.rfile.read(content_len).decode("utf-8")
+        payload = json.loads(post_body) if post_body else {}
+
+        # Outbound endpoint
+        if parsed.path in ("/messages/outbound", "/sms/send", "/api/sms/send"):
+            if self.__class__.fail_next_outbound:
+                self.__class__.fail_next_outbound = False
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"error": "Simulated upstream provider outage"}')
+                return
+
+            recipient = payload.get("to") or payload.get("recipient")
+            text = payload.get("text") or payload.get("message")
+            sender = payload.get("from") or payload.get("sender") or "Snippen"
+
+            if not recipient or not text:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"error": "Missing recipient or text"}')
+                return
+
+            msg_id = str(uuid.uuid4())
+            record = {
+                "id": msg_id,
+                "direction": "outbound",
+                "to": recipient,
+                "from": sender,
+                "text": text,
+                "status": "sent",
+                "createdAt": "2026-09-01T14:00:00.000Z",
+                "metadata": payload.get("metadata", {}),
+            }
+            self.__class__.messages.append(record)
+
+            self.send_response(201)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(record).encode("utf-8"))
+            return
+
+        # Test injection endpoint for inbound SMS
+        if parsed.path in ("/messages/inbound", "/simulate/inbound"):
+            sender = payload.get("from") or payload.get("sender")
+            text = payload.get("text") or payload.get("message")
+            recipient = payload.get("to") or payload.get("recipient")
+
+            msg_id = str(uuid.uuid4())
+            record = {
+                "id": msg_id,
+                "direction": "inbound",
+                "from": sender,
+                "to": recipient,
+                "text": text,
+                "status": "received",
+                "createdAt": "2026-09-01T14:05:00.000Z",
+                "metadata": payload.get("metadata", {}),
+            }
+            self.__class__.messages.append(record)
+
+            self.send_response(201)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"message": record}).encode("utf-8"))
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        qs = parse_qs(parsed.query)
+
+        if parsed.path in ("/messages", "/api/messages"):
+            direction_filter = qs.get("direction", [None])[0]
+            matched = self.__class__.messages
+            if direction_filter:
+                matched = [m for m in matched if m.get("direction") == direction_filter]
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"messages": matched, "count": len(matched)}).encode("utf-8")
+            )
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_DELETE(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path in ("/messages", "/api/messages"):
+            count = len(self.__class__.messages)
+            self.__class__.messages = []
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"message": "All messages cleared", "count": count}).encode("utf-8")
+            )
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress standard HTTP server logging."""
+
+
+@pytest.fixture
+def fake_provider_server():
+    """Spin up local fake provider HTTP server."""
+    FakeSmsProviderSimulator.reset()
+    server = HTTPServer(("127.0.0.1", 0), FakeSmsProviderSimulator)
+    port = server.server_port
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    base_url = f"http://127.0.0.1:{port}"
+    yield base_url
+    server.shutdown()
+    server.server_close()
+
+
+def test_e2e_outbound_sms_to_fake_provider(tmp_path, fake_provider_server):
+    """Verify that an outbound SMS is dispatched to the fake provider and status transitions to 'sent'."""
+
+    async def _test():
+        db_path = str(tmp_path / "test_e2e_gateway.db")
+        config = GatewayConfig(
+            provider="fake",
+            provider_url=fake_provider_server,
+            database_path=db_path,
+            sync_enabled=False,
+        )
+        storage = MessageStorage(db_path)
+        gateway = GatewayService(config=config, storage=storage)
+
+        await gateway.start()
+
+        # Enqueue an outbound message
+        msg = gateway.enqueue_outbox(
+            recipient="+4791234567",
+            body="Velkommen til Snippen! Din kode er 9911",
+            sender="Snippen",
+        )
+        assert msg.id is not None
+        assert msg.status == MessageStatus.PENDING
+
+        # Process outbox
+        processed = await gateway.process_outbox()
+        assert len(processed) == 1
+        assert processed[0].status == MessageStatus.SENT
+        assert processed[0].modem_message_id is not None
+
+        # Check fake provider received the message
+        stored_in_provider = FakeSmsProviderSimulator.messages
+        assert len(stored_in_provider) == 1
+        assert stored_in_provider[0]["to"] == "+4791234567"
+        assert stored_in_provider[0]["text"] == "Velkommen til Snippen! Din kode er 9911"
+        assert stored_in_provider[0]["id"] == processed[0].modem_message_id
+
+        await gateway.stop()
+
+    asyncio.run(_test())
+
+
+def test_e2e_inbound_sms_polling_and_deduplication(tmp_path, fake_provider_server):
+    """Verify inbound SMS injection, polling, ingestion with 'received' status, and deduplication."""
+
+    async def _test():
+        db_path = str(tmp_path / "test_e2e_inbound.db")
+        config = GatewayConfig(
+            provider="fake",
+            provider_url=fake_provider_server,
+            database_path=db_path,
+            sync_enabled=False,
+            booking_resolution_enabled=False,
+        )
+        storage = MessageStorage(db_path)
+        gateway = GatewayService(config=config, storage=storage)
+
+        await gateway.start()
+
+        # Inject an inbound message into fake provider
+        injected_id = str(uuid.uuid4())
+        FakeSmsProviderSimulator.messages.append(
+            {
+                "id": injected_id,
+                "direction": "inbound",
+                "from": "+4799887766",
+                "to": "Snippen",
+                "text": "Hei, når åpner døren?",
+                "status": "received",
+                "createdAt": "2026-09-01T14:10:00.000Z",
+            }
+        )
+
+        # Poll incoming messages
+        received_msgs = await gateway.poll_incoming_messages()
+        assert len(received_msgs) == 1
+        assert received_msgs[0].sender == "+4799887766"
+        assert received_msgs[0].body == "Hei, når åpner døren?"
+        assert received_msgs[0].direction == MessageDirection.INBOUND
+        assert received_msgs[0].status == MessageStatus.RECEIVED
+        assert received_msgs[0].modem_message_id == injected_id
+
+        # Verify message is persisted in local database
+        inbox_messages = storage.get_inbox()
+        assert len(inbox_messages) == 1
+        assert inbox_messages[0].modem_message_id == injected_id
+
+        # Poll again - should deduplicate and return 0 new messages
+        second_poll = await gateway.poll_incoming_messages()
+        assert len(second_poll) == 0
+
+        # Total inbox in storage should still be 1
+        assert storage.count_inbox() == 1
+
+        await gateway.stop()
+
+    asyncio.run(_test())
+
+
+def test_e2e_outbound_failure_transitions_to_failed(tmp_path, fake_provider_server):
+    """Verify that when provider returns 500 or fails, outbox status transitions to 'failed'."""
+
+    async def _test():
+        db_path = str(tmp_path / "test_e2e_failed.db")
+        config = GatewayConfig(
+            provider="fake",
+            provider_url=fake_provider_server,
+            database_path=db_path,
+            sync_enabled=False,
+        )
+        storage = MessageStorage(db_path)
+        gateway = GatewayService(config=config, storage=storage)
+
+        await gateway.start()
+
+        # Trigger failure on next request
+        FakeSmsProviderSimulator.fail_next_outbound = True
+
+        msg = gateway.enqueue_outbox(
+            recipient="+4791234567",
+            body="Feilende melding test",
+        )
+        assert msg.id is not None
+
+        processed = await gateway.process_outbox()
+        assert len(processed) == 1
+        assert processed[0].status == MessageStatus.FAILED
+        assert "500" in (processed[0].error_message or "")
+
+        await gateway.stop()
+
+    asyncio.run(_test())

--- a/tests/test_http_provider.py
+++ b/tests/test_http_provider.py
@@ -1,0 +1,215 @@
+"""Unit tests for HttpSmsProvider."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from snippen_sms.providers.base import IncomingMessage, SendResult
+from snippen_sms.providers.http import HttpSmsProvider
+
+
+class MockHttpHandler(BaseHTTPRequestHandler):
+    """Mock HTTP handler simulating remote SMS HTTP provider."""
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        content_len = int(self.headers.get("Content-Length", 0))
+        post_body = self.rfile.read(content_len).decode("utf-8")
+        payload = json.loads(post_body) if post_body else {}
+
+        if parsed.path == "/messages/outbound":
+            if payload.get("to") == "+4700000000_FAIL":
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"error": "Simulated provider internal error"}')
+                return
+            elif payload.get("to") == "+4700000000_BAD":
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"error": "Invalid recipient phone number"}')
+                return
+
+            self.send_response(201)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            response_obj = {
+                "id": "prov-msg-12345",
+                "direction": "outbound",
+                "to": payload.get("to"),
+                "from": payload.get("from", "Snippen"),
+                "text": payload.get("text"),
+                "status": "sent",
+                "createdAt": "2026-09-01T12:00:00Z",
+            }
+            self.wfile.write(json.dumps(response_obj).encode("utf-8"))
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        qs = parse_qs(parsed.query)
+
+        if parsed.path == "/messages" and qs.get("direction") == ["inbound"]:
+            if self.headers.get("X-Trigger-Error") == "500":
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"error": "Internal server error"}')
+                return
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            response_obj = {
+                "messages": [
+                    {
+                        "id": "inbound-msg-1",
+                        "direction": "inbound",
+                        "from": "+4799887766",
+                        "to": "Snippen",
+                        "text": "Hei, adgangskode mottatt",
+                        "status": "received",
+                        "createdAt": "2026-09-01T12:30:00Z",
+                    },
+                    {
+                        "id": "inbound-msg-2",
+                        "direction": "inbound",
+                        "from": "+4711223344",
+                        "to": "Snippen",
+                        "text": "Takk!",
+                        "status": "received",
+                        "createdAt": "2026-09-01T12:35:00Z",
+                    },
+                ],
+                "count": 2,
+            }
+            self.wfile.write(json.dumps(response_obj).encode("utf-8"))
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress stdout log messages during test run."""
+
+
+@pytest.fixture
+def mock_server():
+    """Start local mock HTTP server for testing HttpSmsProvider."""
+    server = HTTPServer(("127.0.0.1", 0), MockHttpHandler)
+    port = server.server_port
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    base_url = f"http://127.0.0.1:{port}"
+    yield base_url
+    server.shutdown()
+    server.server_close()
+
+
+def test_http_provider_send_sms_success(mock_server: str):
+    async def _test():
+        provider = HttpSmsProvider(base_url=mock_server, timeout_seconds=3.0)
+        await provider.open()
+
+        result: SendResult = await provider.send_sms(
+            recipient="+4799887766",
+            body="Adgangskode: 1234",
+        )
+
+        assert result.success is True
+        assert result.message_id == "prov-msg-12345"
+        assert result.error_message is None
+
+        await provider.close()
+
+    asyncio.run(_test())
+
+
+def test_http_provider_send_sms_bad_request(mock_server: str):
+    async def _test():
+        provider = HttpSmsProvider(base_url=mock_server, timeout_seconds=3.0)
+        await provider.open()
+
+        result: SendResult = await provider.send_sms(
+            recipient="+4700000000_BAD",
+            body="Invalid recipient test",
+        )
+
+        assert result.success is False
+        assert result.message_id is None
+        assert "HTTP 400" in (result.error_message or "")
+
+        await provider.close()
+
+    asyncio.run(_test())
+
+
+def test_http_provider_send_sms_server_error(mock_server: str):
+    async def _test():
+        provider = HttpSmsProvider(base_url=mock_server, timeout_seconds=3.0)
+        await provider.open()
+
+        result: SendResult = await provider.send_sms(
+            recipient="+4700000000_FAIL",
+            body="Internal error test",
+        )
+
+        assert result.success is False
+        assert result.message_id is None
+        assert "HTTP 500" in (result.error_message or "")
+
+        await provider.close()
+
+    asyncio.run(_test())
+
+
+def test_http_provider_send_sms_connection_refused():
+    async def _test():
+        # Use unused port where no server is running
+        provider = HttpSmsProvider(base_url="http://127.0.0.1:59999", timeout_seconds=1.0)
+        result = await provider.send_sms(recipient="+4799887766", body="Test")
+
+        assert result.success is False
+        assert result.message_id is None
+        assert result.error_message is not None
+
+    asyncio.run(_test())
+
+
+def test_http_provider_receive_sms_success(mock_server: str):
+    async def _test():
+        provider = HttpSmsProvider(base_url=mock_server, timeout_seconds=3.0)
+        await provider.open()
+
+        messages: list[IncomingMessage] = await provider.receive_sms()
+
+        assert len(messages) == 2
+        assert messages[0].sender == "+4799887766"
+        assert messages[0].body == "Hei, adgangskode mottatt"
+        assert messages[0].provider_message_id == "inbound-msg-1"
+        assert messages[1].sender == "+4711223344"
+        assert messages[1].body == "Takk!"
+        assert messages[1].provider_message_id == "inbound-msg-2"
+
+        await provider.close()
+
+    asyncio.run(_test())
+
+
+def test_http_provider_receive_sms_connection_failure():
+    async def _test():
+        provider = HttpSmsProvider(base_url="http://127.0.0.1:59999", timeout_seconds=1.0)
+        messages = await provider.receive_sms()
+        assert messages == []
+
+    asyncio.run(_test())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,3 +148,38 @@ def test_handle_sync_cli():
             database_path=":memory:",
         )
         assert exit_code == 1
+
+
+def test_cli_parser_send_command():
+    parser = build_parser()
+    args_send = parser.parse_args(
+        [
+            "send",
+            "--to",
+            "+4799887766",
+            "--message",
+            "Test SMS content",
+            "--provider",
+            "fake",
+            "--provider-url",
+            "http://localhost:3000",
+        ]
+    )
+    assert args_send.command == "send"
+    assert args_send.to == "+4799887766"
+    assert args_send.message == "Test SMS content"
+    assert args_send.provider == "fake"
+    assert args_send.provider_url == "http://localhost:3000"
+
+
+def test_handle_send_cli():
+    from snippen_sms.main import handle_send
+
+    # Successful direct send with memory provider
+    exit_code = handle_send(
+        recipient="+4799887766",
+        body="Test message body",
+        provider_name="memory",
+        database_path=":memory:",
+    )
+    assert exit_code == 0

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -165,3 +165,22 @@ def test_in_memory_provider_clear():
         assert res.success is True
 
     asyncio.run(_test())
+
+
+def test_provider_registry_http_and_fake():
+    from snippen_sms.providers import HttpSmsProvider, get_provider
+
+    prov_http = get_provider("http", base_url="http://localhost:3000")
+    assert isinstance(prov_http, HttpSmsProvider)
+    assert prov_http.base_url == "http://localhost:3000"
+
+    prov_fake = get_provider("fake", base_url="http://fake-host:8080")
+    assert isinstance(prov_fake, HttpSmsProvider)
+    assert prov_fake.base_url == "http://fake-host:8080"
+
+    prov_testing = get_provider("snippen-testing")
+    assert isinstance(prov_testing, HttpSmsProvider)
+    assert prov_testing.base_url == "http://127.0.0.1:3000"
+
+    with pytest.raises(ValueError, match="Unknown SMS provider 'unknown_provider'"):
+        get_provider("unknown_provider")


### PR DESCRIPTION
## Summary
Closes #42.

Connects `snippen-sms-service` to external HTTP SMS providers and the `snippen-testing` fake SMS provider.

### Changes
- Implemented `HttpSmsProvider` in `src/snippen_sms/providers/http.py` supporting outbound SMS transmission (`POST /messages/outbound`) and inbound message polling (`GET /messages?direction=inbound`).
- Registered `http`, `fake`, and `snippen-testing` in `PROVIDER_REGISTRY`.
- Added `SNIPPEN_SMS_PROVIDER_URL` and `SNIPPEN_SMS_PROVIDER_TIMEOUT` environment variables and `--provider-url` CLI parameter.
- Added `snippen-sms send` CLI command for direct SMS dispatch.
- Added unit tests (`tests/test_http_provider.py`) and end-to-end integration tests (`tests/test_fake_provider_e2e.py`).
- Updated `README.md`, `DEV_README.md`, `CHANGELOG.md`, and bumped package version to `0.15.0`.