### PR TITLE
(#44) Add Dockerfile and healthcheck for containerized integration testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Git
+.git
+.github
+.gitmodules
+
+# Python cache & virtual environments
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+.venv
+build/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Testing & Linting
+.pytest_cache/
+.ruff_cache/
+tests/
+
+# Documentation & IDE
+docs/
+.vscode/
+.idea/
+.agents/
+
+# Local databases
+data/*.db
+data/*.sqlite
+data/*.sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-09-03
+
+### Added
+- Production-ready `Dockerfile` based on `python:3.14-slim` with non-root user `appuser`, volume mount `/app/data`, and container `HEALTHCHECK` (`#44`).
+- Container ignore configuration in `.dockerignore` excluding caches, tests, and temporary artifacts (`#44`).
+- CLI subcommands `snippen-sms status` and `snippen-sms health` with optional `--json` format output and exit code reporting for container health inspection (`#44`).
+- Automated startup migration tests on fresh SQLite database paths (`#44`).
+
+### Changed
+- Extended `README.md` and `DEV_README.md` with Docker build, run, and containerized integration testing instructions (`#44`).
+
 ## [0.15.0] - 2026-09-01
 
 ### Added

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -56,6 +56,8 @@ snippen-sms-service/
 │   ├── test_sync.py          # SyncService coordination & retry tests
 │   ├── test_updater.py       # GitHub release version checking & updater unit tests
 │   └── test_validate_pr.py   # PR validation tests
+├── .dockerignore             # Docker build context exclusions
+├── Dockerfile                # Production container image definition (Python 3.14-slim)
 ├── pyproject.toml            # Python packaging and dependency config
 ├── README.md                 # User documentation
 ├── DEV_README.md             # Developer documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# ==============================================================================
+# Snippen SMS Gateway Service Dockerfile
+# ==============================================================================
+FROM python:3.14-slim
+
+# Prevent Python from writing .pyc files and buffer stdout/stderr
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    SNIPPEN_SMS_DATABASE_PATH=/app/data/sms_gateway.db \
+    SNIPPEN_SMS_LOG_LEVEL=INFO
+
+WORKDIR /app
+
+# Create unprivileged user and persistent data volume directory
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -d /app -s /bin/bash appuser && \
+    mkdir -p /app/data && \
+    chown -R appuser:appuser /app
+
+# Copy project definition and source code
+COPY --chown=appuser:appuser pyproject.toml README.md ./
+COPY --chown=appuser:appuser src/ ./src/
+
+# Install application package
+RUN pip install --no-cache-dir .
+
+# Switch to unprivileged runtime user
+USER appuser
+
+# Declare persistent data volume for SQLite database
+VOLUME ["/app/data"]
+
+# Healthcheck verifying database accessibility and gateway readiness
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
+    CMD snippen-sms status || exit 1
+
+# Default entrypoint runs the SMS gateway daemon
+ENTRYPOINT ["snippen-sms"]
+CMD ["run"]

--- a/README.md
+++ b/README.md
@@ -144,6 +144,59 @@ curl -X DELETE "http://127.0.0.1:3000/messages"
 
 ---
 
+Check gateway service health and diagnostics:
+
+```bash
+# Check service and database health in human-readable format
+snippen-sms status
+
+# Check health in structured JSON format
+snippen-sms status --json
+
+# Alias subcommand
+snippen-sms health
+```
+
+---
+
+## Running with Docker
+
+`snippen-sms-service` includes a production-ready `Dockerfile` based on `python:3.14-slim` running as an unprivileged non-root user (`appuser`).
+
+### 1. Build the Docker Image
+
+```bash
+docker build -t snippen-sms-service .
+```
+
+### 2. Run the Container
+
+Run the gateway daemon with a persistent volume for the SQLite database:
+
+```bash
+docker run -d \
+  --name snippen-sms-service \
+  --restart unless-stopped \
+  -v snippen-sms-data:/app/data \
+  -e SNIPPEN_SMS_PROVIDER=http \
+  -e SNIPPEN_SMS_PROVIDER_URL=http://fake-sms-provider:3000 \
+  -e SNIPPEN_SMS_API_URL=http://snippen-booking:8080/wp-json/snippen/v1/sms \
+  -e SNIPPEN_SMS_API_TOKEN=test-integration-token \
+  -e SNIPPEN_SMS_SYNC_INTERVAL=1.0 \
+  -e SNIPPEN_SMS_POLL_INTERVAL=1.0 \
+  snippen-sms-service
+```
+
+### 3. Container Healthcheck
+
+The container includes a built-in `HEALTHCHECK` running `snippen-sms status || exit 1`. You can check the container status at any time:
+
+```bash
+docker inspect --format='{{json .State.Health}}' snippen-sms-service
+```
+
+---
+
 Check for software updates and upgrade:
 
 ```bash

--- a/docs/sms-service-test-queries/snippen-sms-service - health.yml
+++ b/docs/sms-service-test-queries/snippen-sms-service - health.yml
@@ -1,0 +1,16 @@
+info:
+  name: snippen-sms-service - health
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: http://localhost:3000/health
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
+  forwardAuthorizationHeader: false

--- a/src/snippen_sms/__init__.py
+++ b/src/snippen_sms/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 from snippen_sms.client import (
     SnippenApiError,

--- a/src/snippen_sms/main.py
+++ b/src/snippen_sms/main.py
@@ -27,10 +27,55 @@ def setup_logging(level_name: str = "INFO") -> None:
     )
 
 
-def get_status() -> dict[str, Any]:
+def get_status(config: GatewayConfig | None = None) -> dict[str, Any]:
     """Return status of the SMS service (convenience helper)."""
-    service = GatewayService()
+    service = GatewayService(config=config)
     return service.get_status()
+
+
+def handle_status(
+    database_path: str = "data/sms_gateway.db",
+    json_output: bool = False,
+) -> int:
+    """Print diagnostic health and status report of the SMS gateway service."""
+    import json
+
+    env_config = GatewayConfig.from_env()
+    config = GatewayConfig(
+        service_name=env_config.service_name,
+        database_path=database_path,
+        provider=env_config.provider,
+        provider_url=env_config.provider_url,
+        sync_enabled=False,
+        check_updates_on_startup=False,
+    )
+    try:
+        status = get_status(config)
+        if json_output:
+            print(json.dumps(status, indent=2))
+        else:
+            print(f"Service:            {status.get('service', 'snippen-sms-service')}")
+            print(f"Status:             {status.get('status', 'unknown')}")
+            print(f"Version:            v{status.get('version', __version__)}")
+            print(f"Provider:           {status.get('provider', 'unknown')}")
+            print(f"Database:           {status.get('database_path', database_path)}")
+            print(
+                f"Messages:           {status.get('total_messages', 0)} total "
+                f"({status.get('outbox_pending', 0)} outbox pending, "
+                f"{status.get('inbox_unprocessed', 0)} inbox unprocessed)"
+            )
+            print(f"API Sync:           {'Enabled' if status.get('sync_enabled') else 'Disabled'}")
+            print(
+                f"Context Resolver:   "
+                f"{'Enabled' if status.get('booking_resolution_enabled') else 'Disabled'}"
+            )
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        if json_output:
+            print(json.dumps({"status": "error", "error": str(exc)}, indent=2))
+        else:
+            print(f"❌ Error checking service status: {exc}")
+        return 1
 
 
 async def run_gateway(config: GatewayConfig) -> None:
@@ -462,6 +507,40 @@ def build_parser() -> argparse.ArgumentParser:
         help="Database file path to apply migrations to post-upgrade",
     )
 
+    # Status subcommand
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show gateway service status and database health",
+    )
+    status_parser.add_argument(
+        "--database-path",
+        type=str,
+        default="data/sms_gateway.db",
+        help="Database file path (default: data/sms_gateway.db)",
+    )
+    status_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output status report in JSON format",
+    )
+
+    # Health subcommand (alias for status)
+    health_parser = subparsers.add_parser(
+        "health",
+        help="Check gateway service health (alias for status)",
+    )
+    health_parser.add_argument(
+        "--database-path",
+        type=str,
+        default="data/sms_gateway.db",
+        help="Database file path (default: data/sms_gateway.db)",
+    )
+    health_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output health report in JSON format",
+    )
+
     return parser
 
 
@@ -508,6 +587,10 @@ def main_cli() -> None:
                 database_path=db_path,
             )
         )
+    elif args.command in ("status", "health"):
+        db_path = getattr(args, "database_path", env_config.database_path)
+        json_out = getattr(args, "json", False)
+        sys.exit(handle_status(database_path=db_path, json_output=json_out))
     else:
         # Default action: run gateway service
         db_path = getattr(args, "database_path", "data/sms_gateway.db")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -183,3 +183,87 @@ def test_handle_send_cli():
         database_path=":memory:",
     )
     assert exit_code == 0
+
+
+def test_cli_parser_status_and_health_commands():
+    parser = build_parser()
+
+    args_status = parser.parse_args(["status", "--database-path", "/tmp/test.db", "--json"])
+    assert args_status.command == "status"
+    assert args_status.database_path == "/tmp/test.db"
+    assert args_status.json is True
+
+    args_health = parser.parse_args(["health", "--database-path", "/tmp/health.db"])
+    assert args_health.command == "health"
+    assert args_health.database_path == "/tmp/health.db"
+    assert args_health.json is False
+
+
+def test_handle_status_cli(capsys):
+    import json
+
+    from snippen_sms.main import handle_status
+
+    # Test standard formatted text output
+    exit_code = handle_status(database_path=":memory:", json_output=False)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Service:" in captured.out
+    assert "Status:" in captured.out
+    assert "Database:           :memory:" in captured.out
+
+    # Test JSON output
+    exit_code_json = handle_status(database_path=":memory:", json_output=True)
+    assert exit_code_json == 0
+    captured_json = capsys.readouterr()
+    data = json.loads(captured_json.out)
+    assert data["service"] == "snippen-sms-service"
+    assert data["database_path"] == ":memory:"
+    assert "outbox_pending" in data
+    assert "inbox_unprocessed" in data
+
+
+def test_handle_status_error(capsys):
+    import json
+    from unittest.mock import patch
+
+    from snippen_sms.main import handle_status
+
+    with patch("snippen_sms.main.get_status", side_effect=RuntimeError("Database disk I/O error")):
+        # Text mode error
+        exit_code = handle_status(database_path=":memory:", json_output=False)
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "❌ Error checking service status: Database disk I/O error" in captured.out
+
+        # JSON mode error
+        exit_code_json = handle_status(database_path=":memory:", json_output=True)
+        assert exit_code_json == 1
+        captured_json = capsys.readouterr()
+        err_data = json.loads(captured_json.out)
+        assert err_data["status"] == "error"
+        assert "Database disk I/O error" in err_data["error"]
+
+
+def test_auto_migration_at_startup_on_fresh_db(tmp_path):
+    from snippen_sms.config import GatewayConfig
+    from snippen_sms.gateway import GatewayService
+    from snippen_sms.migrations import MigrationRunner
+
+    db_file = tmp_path / "subdir" / "new_gateway.db"
+    assert not db_file.exists()
+
+    config = GatewayConfig(database_path=str(db_file), provider="mock")
+    service = GatewayService(config=config)
+
+    # Database file should have been created
+    assert db_file.exists()
+
+    # Verify all migrations were applied automatically
+    with MigrationRunner(str(db_file)) as runner:
+        applied = runner.get_applied_migrations()
+        pending = runner.get_pending_migrations()
+        assert len(applied) >= 4
+        assert len(pending) == 0
+
+    service.storage.close()


### PR DESCRIPTION
## Summary
Closes #44.

- Added production-ready `Dockerfile` (based on `python:3.14-slim`) with unprivileged non-root user `appuser` (UID 1000) and persistent `/app/data` volume.
- Added `.dockerignore` to optimize image builds and exclude transient/cache files.
- Added `snippen-sms status` and `snippen-sms health` CLI subcommands with exit code reporting and optional `--json` structured output.
- Configured container `HEALTHCHECK` instruction running `snippen-sms status || exit 1`.
- Added unit tests for CLI status/health subcommands and verified automatic startup migrations on fresh SQLite databases.
- Updated `README.md` and `DEV_README.md` with Docker build/run commands and health check instructions.
- Bumped version to `0.16.0` with `CHANGELOG.md` entry.

## Verification
- All 155 pytest tests passed.
- Ruff linter passed cleanly.
- Formatter & PR validation scripts passed.