### PR TITLE
(#46) Enable Docker-outside-of-Docker devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,10 @@
   "name": "snippen-sms-service-python",
   "image": "mcr.microsoft.com/devcontainers/python:3.14-bookworm",
   "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "latest",
+      "enableNonRootDocker": "true"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "customizations": {
@@ -13,7 +17,8 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "charliermarsh.ruff",
-        "mermaidchart.vscode-mermaid-chart"
+        "mermaidchart.vscode-mermaid-chart",
+        "ms-azuretools.vscode-docker"
       ],
       "recommendations": [
         "google.google-antigravity"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-09-03
+
+### Added
+- Added `docker-outside-of-docker` devcontainer feature and Docker VS Code extension to `.devcontainer/devcontainer.json` to enable Docker host access and container management within dev environments (`#46`).
+
 ## [0.16.0] - 2026-09-03
 
 ### Added

--- a/src/snippen_sms/__init__.py
+++ b/src/snippen_sms/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 from snippen_sms.client import (
     SnippenApiError,


### PR DESCRIPTION
## Summary
Closes #46.

- Added `ghcr.io/devcontainers/features/docker-outside-of-docker:1` with `enableNonRootDocker: true` to `.devcontainer/devcontainer.json`.
- Added `ms-azuretools.vscode-docker` extension recommendation.
- Bumped package version to `0.16.1` and added `CHANGELOG.md` entry.

## Verification
- Formatter, ruff linter, pytest suite (155 tests), and PR validator passed cleanly.